### PR TITLE
16 accessions pages

### DIFF
--- a/frontend/Gemfile
+++ b/frontend/Gemfile
@@ -20,7 +20,7 @@ gem 'sass-rails'
 gem 'execjs'
 gem 'uglifier'
 
-gem 'bootstrap','~> 4.2.1'
+gem 'bootstrap','~> 4.3.0'
 
 gem 'jquery-rails'
 gem 'jquery-ui-rails'

--- a/frontend/Gemfile.lock
+++ b/frontend/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     benchmark-perf (0.6.0)
     benchmark-trend (0.4.0)
     bindex (0.8.1)
-    bootstrap (4.2.1)
+    bootstrap (4.3.1)
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
@@ -344,7 +344,7 @@ DEPENDENCIES
   activesupport
   atomic (= 1.0.1)
   axe-core-rspec
-  bootstrap (~> 4.2.1)
+  bootstrap (~> 4.3.0)
   capybara
   coffee-rails
   coffee-script

--- a/frontend/app/assets/stylesheets/archivesspace/tables.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/tables.scss
@@ -204,3 +204,7 @@ table.table-spreadsheet {
 .inactive {
   background-color: #ffe6e6 !important;
 }
+
+table .col {
+  width: unset;
+}

--- a/frontend/app/assets/stylesheets/themes/default/default.scss
+++ b/frontend/app/assets/stylesheets/themes/default/default.scss
@@ -44,6 +44,11 @@ body {
 
 .badge {
   background-color: #337ab7;
+  color: white;
+}
+
+.sidebar .badge {
+  border-radius: 20px;
 }
 
 @media print {

--- a/frontend/app/views/accessions/index.html.erb
+++ b/frontend/app/views/accessions/index.html.erb
@@ -8,8 +8,8 @@
   </div>
   <div class="col-md-9">
     <% if user_can?('update_accession_record') %>
-      <div class="record-toolbar">
-        <div class="btn-group pull-right">
+      <div class="record-toolbar d-flex">
+        <div class="btn-group ml-auto border bg-white">
           <% if user_can?('manage_repository') %>
               <%= link_to I18n.t("actions.edit_default_values"), {:controller => :accessions, :action => :defaults}, :class => "btn btn-sm btn-default" %>
           <% end %>

--- a/frontend/app/views/search/_filter.html.erb
+++ b/frontend/app/views/search/_filter.html.erb
@@ -26,7 +26,7 @@
 <% end %>
 
 <% if params["advanced"] != "true" %>
-  <%= form_tag({}, :method => :get) do %>
+  <%= form_tag({}, {:method => :get, :class => 'my-3'}) do %>
     <% query_array = @search_data.query? ? @search_data[:criteria]["q"] : ''%>
     <% build_search_params({"q" => query_array}).each do |k, v| %>
       <% if v.kind_of? Array %>
@@ -37,7 +37,7 @@
         <%= hidden_field_tag k, v %>
       <% end %>
     <% end %>
-    <div class="input-group" style="width:100%">
+    <div class="input-group w-100">
       <label for="filter-text" class="sr-only">Filter by text</label>
       <input class="text-filter-field form-control" type="text" placeholder="<%= I18n.t("search_results.text_placeholder") %>" name="q" value="<%= params[:q] %>" id="filter-text"/>
       <div class="input-group-btn">

--- a/frontend/app/views/search/_listing.html.erb
+++ b/frontend/app/views/search/_listing.html.erb
@@ -4,7 +4,7 @@
 
   <%= render_aspace_partial :partial => "shared/pagination_summary" %>
 
-  <table id="tabledSearchResults" class="table table-striped table-bordered table-condensed table-hover table-sortable table-search-results" <%= 'data-multiselect="true"' if allow_multiselect? %>>
+  <table id="tabledSearchResults" class="table table-striped table-bordered table-condensed table-hover table-sortable table-search-results table-responsive" <%= 'data-multiselect="true"' if allow_multiselect? %>>
     <thead>
       <tr>
         <% @columns.each do |col| %>

--- a/frontend/app/views/shared/_pagination_summary.html.erb
+++ b/frontend/app/views/shared/_pagination_summary.html.erb
@@ -1,58 +1,55 @@
 <% if @search_data %>
 
-  <div class="pull-left">
+  <div class="d-inline-block">
     <%= I18n.t "pagination.summary_prefix" %> <strong><%= @search_data["offset_first"] %></strong> <%= I18n.t "pagination.summary_offset_connector" %> <strong><%= @search_data["offset_last"] %></strong> <%= I18n.t "pagination.summary_total_connector" %> <strong><%= @search_data["total_hits"] %></strong> <%= I18n.t "pagination.summary_suffix" %>
   </div>
-
-  <div class="pull-left" style="position: relative">
-    <span class="btn-group">
-      <label style="float: left;">,&#160;<%= I18n.t("search_sorting.sort_by") %>&#160;</label>
-      <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-        <div class="btn-group">
-          <span class="btn btn-default btn btn-xs"><%= @search_data.sorted_by_label %></span>
-          <span class="btn btn-xs btn-default last"><span class="caret"></span></span>
-        </div>
-      </a>
-      <ul class="dropdown-menu pull-right sort-opts">
-        <% @search_data.sort_fields.each do |field, label| %>
-          <% next if field == 'score' && @search_data.sorted_by?(field) %>
-          <li class="dropdown-submenu">
-            <%= link_to label, build_search_params("sort" => @search_data.sort_filter_for(field, "desc")) %>
-            <ul class="dropdown-menu">
-              <% unless field == 'score' %>
-                <li><%= link_to I18n.t("search_sorting.asc"), build_search_params("sort" => "#{field} asc") %></li>
-              <% end %>
-              <li><%= link_to I18n.t("search_sorting.desc"), build_search_params("sort" => "#{field} desc") %></li>
-            </ul>
-          </li>
-        <% end %>
-      </ul>
+  <div class="d-inline-block">
+    <span class="btn-group align-items-start">
+      <label>,&#160;<%= I18n.t("search_sorting.sort_by") %>&#160;</label>
+      <div class="btn-group align-items-center">
+        <a class="dropdown-toggle border bg-white rounded d-flex align-items-center pr-3" data-toggle="dropdown" href="#">
+          <span class="btn"><%= @search_data.sorted_by_label %></span>
+        </a>
+        <ul class="dropdown-menu">
+          <% @search_data.sort_fields.each do |field, label| %>
+            <% next if field == 'score' && @search_data.sorted_by?(field) %>
+            <li class="dropdown-submenu dropdown-item">
+              <%= link_to label, build_search_params("sort" => @search_data.sort_filter_for(field, "desc")) %>
+              <ul class="dropdown-menu">
+                <% unless field == 'score' %>
+                  <li class='dropdown-item'><%= link_to I18n.t("search_sorting.asc"), build_search_params("sort" => "#{field} asc") %></li>
+                <% end %>
+                <li class='dropdown-item'><%= link_to I18n.t("search_sorting.desc"), build_search_params("sort" => "#{field} desc") %></li>
+              </ul>
+            </li>
+          <% end %>
+        </ul>
+      </div>
     </span>
   </div>
 
   <% if @search_data.sorted? && !@search_data.sorted_by?('score') %>
-    <div class="pull-left" style="position: relative">
-      <span class="btn-group">
-        <label style="float: left;">&#160;<%= I18n.t("search_sorting.and") %>&#160;</label>
-        <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-          <div class="btn-group">
-            <span class="btn btn-xs btn-default"><%= @search_data.sorted_by_label(1) %></span>
-            <span class="btn btn-xs btn-default last"><span class="caret"></span></span>
-          </div>
-        </a>
-        <ul class="dropdown-menu pull-right">
-          <% @search_data.sort_fields.each do |field, label| %>
-            <% if !@search_data.sorted_by?(field) && field != 'score' %>
-              <li class="dropdown-submenu">
-                <%= link_to label, build_search_params("sort2" => @search_data.sort_filter_for(field, "desc")) %>
-                <ul class="dropdown-menu">
-                  <li><%= link_to I18n.t("search_sorting.asc"), build_search_params("sort2" => "#{field} asc") %></li>
-                  <li><%= link_to I18n.t("search_sorting.desc"), build_search_params("sort2" => "#{field} desc") %></li>
-                </ul>
-              </li>
+    <div class="d-inline-block">
+      <span class="btn-group align-items-start">
+        <label>&#160;<%= I18n.t("search_sorting.and") %>&#160;</label>
+        <div class="btn-group">
+          <a class="dropdown-toggle border bg-white rounded d-flex align-items-center pr-3" data-toggle="dropdown" href="#">
+              <span class="btn"><%= @search_data.sorted_by_label(1) %></span>
+          </a>
+          <ul class="dropdown-menu">
+            <% @search_data.sort_fields.each do |field, label| %>
+              <% if !@search_data.sorted_by?(field) && field != 'score' %>
+                <li class="dropdown-submenu dropdown-item">
+                  <%= link_to label, build_search_params("sort2" => @search_data.sort_filter_for(field, "desc")) %>
+                  <ul class="dropdown-menu">
+                    <li class='dropdown-item'><%= link_to I18n.t("search_sorting.asc"), build_search_params("sort2" => "#{field} asc") %></li>
+                    <li class='dropdown-item'><%= link_to I18n.t("search_sorting.desc"), build_search_params("sort2" => "#{field} desc") %></li>
+                  </ul>
+                </li>
+              <% end %>
             <% end %>
-          <% end %>
-        </ul>
+          </ul>
+        </div>
       </span>
     </div>
   <% end %>


### PR DESCRIPTION
# Summary
- bump bootstrap version to fix this bug: https://stackoverflow.com/questions/53921939/bootstrap-4-2-1-failed-to-execute-queryselector-on-document-javascriptv
- fix all tables
- fix the details in the accessions/view pages so they are closer to the old version of the app

# Related
https://gitlab.com/notch8/archivesspace/-/issues/16

# Screenshots

Before
![Screen Shot 2022-08-09 at 1 50 40 PM](https://user-images.githubusercontent.com/73361970/183758259-f6e6de07-e34a-4790-9923-60ee663622a5.png)


After
![Screen Shot 2022-08-09 at 1 49 25 PM](https://user-images.githubusercontent.com/73361970/183758069-59b93b53-0a89-4588-889b-a45cc477e20b.png)

Old Version
<img width="841" alt="Screen_Shot_2022-07-19_at_1 44 58_PM" src="https://user-images.githubusercontent.com/73361970/183758367-60ec42a2-d8fd-410a-9a93-1d545b7cea49.png">




# Acceptance Criteria

- [ ] the accessions overview page looks similar to the bootstrap 3.4 version of the accessions overview page
