### PR TITLE
Fixes view accession page

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/common.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/common.scss
@@ -8,6 +8,10 @@ h2 > .label {
   margin-top: $baseLineHeight / 2;
   vertical-align: top;
   font-size: 40%;
+  &.badge {
+    margin-top: 0;
+    color: white;
+  }
 }
 
 .tab-content {

--- a/frontend/app/assets/stylesheets/archivesspace/form.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/form.scss
@@ -741,6 +741,10 @@ label {
   .form-actions {
     margin: 0;
   }
+
+  &:hover {
+    display: block;
+  }
 }
 
 /* fix typeahead not displaying above modal blockout */

--- a/frontend/app/assets/stylesheets/archivesspace/variables.scss
+++ b/frontend/app/assets/stylesheets/archivesspace/variables.scss
@@ -40,7 +40,7 @@ $white: #fff;
 
 // Accent colors
 // -------------------------
-$blue: #049cdb;
+$blue: #004c7f;
 $blueDark: #0064cd;
 $green: #46a546;
 $red: #9d261d;

--- a/frontend/app/helpers/aspace_form_helper.rb
+++ b/frontend/app/helpers/aspace_form_helper.rb
@@ -723,7 +723,7 @@ module AspaceFormHelper
 
       control_group_classes,
       label_classes,
-      controls_classes = %w(form-group), [], []
+      controls_classes = %w(form-group row), [], []
 
       unless opts[:layout] && opts[:layout] == 'stacked'
         label_classes << "col-sm-#{opts[:label_opts].fetch(:col_size, 2)}"
@@ -902,7 +902,7 @@ module AspaceFormHelper
       html << "<div class='control-label col-sm-2'>"
       html << I18n.t("#{prefix}#{jsonmodel_type.to_s}.#{property}")
       html << "</div>"
-      html << "<div class='label-only col-sm-8'>#{value}</div>"
+      html << "<div class='col-sm-8'>#{value}</div>"
       html << "</div>"
     end
     html << "</div>"
@@ -957,7 +957,7 @@ module AspaceFormHelper
 
     def label_with_field(name, field_html, opts = {})
       return "" if field_html.blank?
-      super(name, field_html, opts.merge({:controls_class => "label-only"}))
+      super(name, field_html, opts.merge({:controls_class => ""}))
     end
 
     def label_and_fourpartid
@@ -1264,11 +1264,11 @@ module AspaceFormHelper
         end
       end
 
-      html << "<div class='form-group'>"
+      html << "<div class='form-group row'>"
       html << "<div class='control-label col-sm-2'>"
       html << I18n.t("#{prefix}#{jsonmodel_type.to_s}.#{property}")
       html << "</div>"
-      html << "<div class='label-only col-sm-8'>#{value}</div>"
+      html << "<div class='col-sm-8'>#{value}</div>"
       html << "</div>"
     end
 

--- a/frontend/app/views/accessions/_toolbar.html.erb
+++ b/frontend/app/views/accessions/_toolbar.html.erb
@@ -1,27 +1,27 @@
 <% if user_can?('update_accession_record') %>
   <div class="row">
     <div class="col-md-12">
-      <div class="record-toolbar">
+      <div class="record-toolbar d-flex">
         <% if not @accession.suppressed %>
           <% if !['edit', 'update'].include?(controller.action_name) %>
-            <div class="btn-group pull-left">
+            <div class="btn-group align-items-center">
               <%= link_to I18n.t("actions.edit"), {:controller => :accessions, :action => :edit, :id => @accession.id}, :class => "btn btn-sm btn-primary" %>
             </div>
           <% end %>
         <% end %>
         <% if ['new', 'create', 'edit', 'update'].include?(controller.action_name) %>
-          <div class="pull-left save-changes">
+          <div class="save-changes">
             <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
           </div>
         <% end %>
         <% if ['edit', 'update'].include?(controller.action_name) %>
-          <div class="pull-left revert-changes">
+          <div class="revert-changes">
             <%= link_to I18n.t("actions.revert"), {:controller => :accessions, :action => :edit, :id => @accession.id}, :class => "btn btn-sm btn-default" %>
             <%= I18n.t("actions.toolbar_disabled_message") %>
           </div>
         <% end %>
-        <div class="btn-toolbar pull-right">
-          <div class="btn-group">
+        <div class="d-flex ml-auto">
+          <div class="btn-group align-items-center bg-white rounded border">
             <% if AppConfig[:enable_public] %>
               <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => @accession} %>
             <% end %>
@@ -29,52 +29,49 @@
               <%= render_aspace_partial :partial => "shared/event_dropdown", :locals => {:record => @accession } %>
             <% end %>
             <% if not @accession.suppressed %>
-              <div id="spawn-dropdown" class="btn btn-inline-form">
+              <div id="spawn-dropdown" class="btn btn-inline-form border-left">
                 <a class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);">
                   <%= I18n.t "actions.spawn" %>
                   <span class="caret"></span>
                 </a>
-                <ul class="dropdown-menu open-aligned-right">
-                  <li>
+                <ul class="dropdown-menu pr-3">
+                  <li class='dropdown-item'>
                     <%= link_to "<span class='icomoon icon-accession'></span> #{I18n.t("accession._singular")}".html_safe, :controller => :accessions, :action => :new, :accession_id => @accession.id %>
                   </li>
-                  <li>
+                  <li class='dropdown-item'>
                     <%= link_to "<span class='icomoon icon-resource'></span> #{I18n.t("resource._singular")}".html_safe, :controller => :resources, :action => :new, :accession_id => @accession.id %>
                   </li>
                 </ul>
               </div>
             <% end %>
-            <% if user_can?('transfer_archival_record') %>
-              <%=
-                 render_aspace_partial :partial => "shared/transfer_dropdown",
-                        :locals => {:record => @accession,
-                                    :controller => controller.controller_name,
-                                    :confirmation_title => I18n.t("actions.transfer_confirm_title"),
-                                    :confirmation_msg => I18n.t("actions.transfer_confirm_message",
-                                                                :target => @accession.title)}
-              %>
-            <% end %>
-
-            <div class="btn-group dropdown" id="other-dropdown">
-              <a class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+            <div class='border-left'>
+              <% if user_can?('transfer_archival_record') %>
+                <%=
+                  render_aspace_partial :partial => "shared/transfer_dropdown",
+                          :locals => {:record => @accession,
+                                      :controller => controller.controller_name,
+                                      :confirmation_title => I18n.t("actions.transfer_confirm_title"),
+                                      :confirmation_msg => I18n.t("actions.transfer_confirm_message",
+                                                                  :target => @accession.title)}
+                %>
+              <% end %>
+            </div>
+            <div class="btn-group dropdown border-left" id="other-dropdown">
+              <a class="btn btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <%= I18n.t('actions.more') %>
                 <span class="caret"></span>
               </a>
 
               <ul class="dropdown-menu">
-                <li><%= render_aspace_partial :partial => "extent_calculator/toolbar_button", :locals => {:record => @accession} %></li>
+                <li class='dropdown-item'><%= render_aspace_partial :partial => "extent_calculator/toolbar_button", :locals => {:record => @accession} %></li>
                 <% if user_can?('update_assessment_record') %>
-                  <li><%= link_to I18n.t('assessment._frontend.action.create_for_record'), {:controller => :assessments, :action => :new, :record_uri => @accession.uri} %></li>
+                  <li class='dropdown-item'><%= link_to I18n.t('assessment._frontend.action.create_for_record'), {:controller => :assessments, :action => :new, :record_uri => @accession.uri} %></li>
                 <% end %>
               </ul>
             </div>
-
-            <% if user_can?('suppress_archival_record') || user_can?('delete_archival_record') %>
-              <div class="btn-group"><div class="toolbar-spacer"></div></div>
-            <% end %>
-
-
-            <% if user_can?('suppress_archival_record') || user_can?('delete_archival_record') %>
+          </div><!-- btn-group -->
+          <% if user_can?('suppress_archival_record') || user_can?('delete_archival_record') %>
+            <div class="btn-group align-items-center"><div class="toolbar-spacer"></div>
               <% if user_can?('suppress_archival_record') %>
                 <div class="btn btn-inline-form">
                   <% if @accession.suppressed %>
@@ -107,9 +104,9 @@
                   <%= button_delete_action url_for(:controller => :accessions, :action => :delete, :id => @accession.id), { :"data-title" => I18n.t("actions.delete_confirm_title", :title => @accession.title) } %>
                 </div>
               <% end %>
-            <% end %>
-          </div><!-- btn-group -->
-        </div><!-- btn-toolbar pull-right -->
+            </div>
+          <% end %>
+        </div><!-- btn-toolbar ml-auto -->
         <div class="clearfix"></div>
       </div><!-- record-toolbar -->
     </div><!-- col-md-12 -->

--- a/frontend/app/views/accessions/show.html.erb
+++ b/frontend/app/views/accessions/show.html.erb
@@ -10,12 +10,12 @@
     <%= render_aspace_partial :partial => "accessions/toolbar" %>
     <div class="record-pane">
       <%= readonly_context :accession, @accession do |readonly| %>
-          <h2><%= clean_mixed_content(@accession.display_string) %> <span class="label label-info label-default"><%= I18n.t("accession._singular") %></span></h2>
+          <h2 class='my-3'><%= clean_mixed_content(@accession.display_string) %> <span class="badge label"><%= I18n.t("accession._singular") %></span></h2>
 
           <%= render_aspace_partial :partial => "shared/flash_messages" %>
 
           <% define_template "accession", jsonmodel_definition(:accession) do |form| %>
-          <section id="basic_information">
+          <section id="basic_information" class="py-3">
             <h3><%= I18n.t "accession._frontend.section.basic_information" %></h3>
 
             <%= render_plugin_partials("top_of_basic_information_accession",

--- a/frontend/app/views/assessments/_embedded.html.erb
+++ b/frontend/app/views/assessments/_embedded.html.erb
@@ -8,9 +8,9 @@
 %>
 
 <section id="<%= section_id %>" class="subrecord-form-dummy">
-  <h3 class="subrecord-form-heading">
+  <h3 class="subrecord-form-heading d-flex align-items-center">
     <%= heading_text %>
-    <%= link_to I18n.t("actions.view_search_results"), html_search_url, :class => "btn btn-sm btn-default pull-right" %>
+    <%= link_to I18n.t("actions.view_search_results"), html_search_url, :class => "btn ml-auto border rounded bg-white btn-sm m-2" %>
   </h3>
   <div class="subrecord-form-container">
     <div class="subrecord-form-fields embedded-search" data-url="<%= ajax_search_url %>">

--- a/frontend/app/views/dates/_show.html.erb
+++ b/frontend/app/views/dates/_show.html.erb
@@ -3,12 +3,12 @@
    section_title = "Dates" if section_title.blank?
 %>
 
-<section id="<%= section_id %>">
+<section id="<%= section_id %>" class='py-3'>
   <h3><%= section_title %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details my-3" id="<%= section_id %>_accordion">
     <% dates.each_with_index do | date, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card">
+        <div class="card-header panel-heading">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_date_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/extents/_show.html.erb
+++ b/frontend/app/views/extents/_show.html.erb
@@ -2,12 +2,12 @@
    section_id = "extents" if section_id.blank?
 %>
 
-<section id="<%= section_id %>">
+<section id="<%= section_id %>" class='py-3'>
   <h3><%= I18n.t("extent._plural") %></h3>
-  <div class="panel-group details" id="<%= section_id %>_accordion">
+  <div class="details" id="<%= section_id %>_accordion">
     <% extents.each_with_index do | extent, index | %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
+      <div class="card">
+        <div class="panel-heading card-header">
           <div class="row accordion-toggle collapsed" data-toggle="collapse" data-parent="#<%= section_id %>_accordion" href="#<%= section_id %>_extent_<%= index %>">
             <div class="col-md-1">
               <span class="glyphicon"></span>

--- a/frontend/app/views/resources/index.html.erb
+++ b/frontend/app/views/resources/index.html.erb
@@ -17,7 +17,7 @@
                 <%= I18n.t("actions.edit_default_values") %>
                 <span class="caret"></span>
               </a>
-              <ul class="dropdown-menu open-aligned-right">
+              <ul class="dropdown-menu dropdown-menu-right">
                 <li><%= link_to I18n.t("resource._singular"), {:controller => :resources, :action => :defaults} %></li>
                 <li> <%= link_to I18n.t("resource_component._singular"), {:controller => :archival_objects, :action => :defaults} %></li>
               </ul>

--- a/frontend/app/views/search/_embedded.html.erb
+++ b/frontend/app/views/search/_embedded.html.erb
@@ -9,7 +9,7 @@
 <section id="<%= section_id %>" class="subrecord-form-dummy">
   <h3 class="subrecord-form-heading">
     <%= heading_text %>
-    <%= link_to I18n.t("actions.view_search_results"), html_search_url, :class => "btn btn-sm btn-default pull-right" %>
+    <%= link_to I18n.t("actions.view_search_results"), html_search_url, :class => "btn btn-sm btn-default ml-auto" %>
   </h3>
   <div class="subrecord-form-container">
     <div class="subrecord-form-fields embedded-search" data-url="<%= ajax_search_url %>">

--- a/frontend/app/views/shared/_actions.html.erb
+++ b/frontend/app/views/shared/_actions.html.erb
@@ -1,9 +1,9 @@
 <% unless deleted(record) %>
-  <div class="btn-group">
+  <div class="btn-group rounded bg-white border">
     <% disabled = "disabled" if JSON.parse(record['json'])['inactive_record'] %>
-    <%= link_to I18n.t("actions.view"), {:controller => :resolver, :action => :resolve_readonly, :uri => record["id"]}, :class => "btn btn-xs btn-default", :disabled => disabled %>
+    <%= link_to I18n.t("actions.view"), {:controller => :resolver, :action => :resolve_readonly, :uri => record["id"]}, :class => "btn", :disabled => disabled %>
     <% if can_edit_search_result?(record) %>
-      <%= link_to I18n.t("actions.edit"), {:controller => :resolver, :action => :resolve_edit, :uri => record["id"]}, :class => "btn btn-xs btn-primary" %>
+      <%= link_to I18n.t("actions.edit"), {:controller => :resolver, :action => :resolve_edit, :uri => record["id"]}, :class => "btn btn-primary" %>
     <% end %>
   </div>
   <% if record['primary_type'] === "repository" and @repositories.any?{|r| r['uri'] === record['id']} %>

--- a/frontend/app/views/shared/_event_dropdown.html.erb
+++ b/frontend/app/views/shared/_event_dropdown.html.erb
@@ -6,17 +6,17 @@
     <button class="btn btn-sm btn-default dropdown-toggle add-event-action" data-toggle="dropdown" role="button" aria-expanded="false" title="<%= I18n.t("actions.add_event") %>">
       <%= I18n.t("actions.add_event") %> <span class="caret"></span>
     </button>
-    <ul class="dropdown-menu add-event-form open-aligned-right">
-      <li>
+    <ul class="dropdown-menu add-event-form dropdown-menu-right">
+      <li class=dropdown-item'>
         <%= form_context :add_event, {} do |form| %>
           <fieldset>
             <legend class="sr-only">Add event:</legend>
             <label for="add_event_event_type"><%=  I18n.t("actions.add_event_event_type") %></label>
-            <%= select_tag "add_event_event_type", options_for_select(event_types.map{|event_type| [I18n.t("enumerations.event_event_type.#{event_type}", :default => event_type), event_type]}), :'aria-labelledby' => "form_add_event" %>
+            <%= select_tag "add_event_event_type", options_for_select(event_types.map{|event_type| [I18n.t("enumerations.event_event_type.#{event_type}", :default => event_type), event_type]}), :'aria-labelledby' => "form_add_event"%>
           </fieldset>
           <div class="form-actions">
-            <button class="btn add-event-button btn-default"><%= I18n.t("actions.add_event") %></button>
-            <a class="btn btn-close pull-right btn-default" href="#"><%= I18n.t("actions.cancel") %></a>
+            <button class="btn add-event-button border"><%= I18n.t("actions.add_event") %></button>
+            <a class="btn btn-close ml-auto btn-danger" href="#"><%= I18n.t("actions.cancel") %></a>
           </div>
         <% end %>
       </li>

--- a/frontend/app/views/shared/_merge_dropdown.html.erb
+++ b/frontend/app/views/shared/_merge_dropdown.html.erb
@@ -8,7 +8,7 @@
     <button class="btn btn-sm btn-default dropdown-toggle merge-action" data-toggle="dropdown" role="button" aria-expanded="false" title="<%= I18n.t("actions.merge") %>">
       <%= I18n.t("actions.merge") %> <span class="caret"></span>
     </button>
-    <ul class="dropdown-menu merge-form open-aligned-right" role="none">
+    <ul class="dropdown-menu merge-form dropdown-menu-right" role="none">
       <li>
       <p><%= I18n.t("#{singular}._frontend.messages.merge_description") %>   <%= record.title %></p>
         <%= form_context :merge, {} do |form| %>

--- a/frontend/app/views/shared/_resource_toolbar.html.erb
+++ b/frontend/app/views/shared/_resource_toolbar.html.erb
@@ -54,7 +54,7 @@
               <%= I18n.t("actions.export") %>
               <span class="caret"></span>
             </a>
-            <ul class="dropdown-menu open-aligned-right">
+            <ul class="dropdown-menu dropdown-menu-rightt">
               <%= yield :exports %>
             </ul>
           </div>

--- a/frontend/app/views/shared/_subrecord_form.html.erb
+++ b/frontend/app/views/shared/_subrecord_form.html.erb
@@ -43,7 +43,7 @@
      <% if custom_action_template %>
        <%= render :partial => custom_action_template %>
      <% else %>
-       <button class="btn btn-sm btn-default pull-right"><%= I18n.t("#{i18n_prefix}#{action_button_override}._frontend.action.add") %></button>
+       <button class="btn btn-sm btn-default ml-auto"><%= I18n.t("#{i18n_prefix}#{action_button_override}._frontend.action.add") %></button>
      <% end %>
     <% end %>
 

--- a/frontend/app/views/shared/_transfer_dropdown.html.erb
+++ b/frontend/app/views/shared/_transfer_dropdown.html.erb
@@ -10,7 +10,7 @@
     <button class="btn btn-sm btn-default dropdown-toggle transfer-action" data-toggle="dropdown" role="button" aria-expanded="false" title="<%= I18n.t("actions.transfer") %>">
       <%= I18n.t("actions.transfer") %> <span class="caret"></span>
     </button>
-    <ul class="dropdown-menu open-aligned-right transfer-form" role="none">
+    <ul class="dropdown-menu dropdown-menu-right transfer-form" role="none">
       <li>
         <p><%= I18n.t("#{singular}._frontend.messages.transfer_description") %></p>
         <%= form_context :transfer, {} do |form| %>
@@ -24,14 +24,14 @@
              button_confirm_action(I18n.t("actions.transfer"),
                                    url_for({:controller => controller, :action => :transfer, :id => record.id}.merge(extra_params)),
                                    {
-                                     :class => "btn pull-left btn-default transfer-button",
+                                     :class => "btn mr-auto transfer-button border",
                                      :"data-title" => confirmation_title,
                                      :"data-message" => confirmation_msg,
                                      :"data-confirm-btn-label" => "#{I18n.t("actions.transfer")}",
                                      :"data-confirm-btn-class" => "btn"
                                    })
           %>
-          <a class="btn pull-right btn-default btn-cancel" href="#"><%= I18n.t("actions.cancel") %></a>
+          <a class="btn ml-auto btn-danger" href="#"><%= I18n.t("actions.cancel") %></a>
         </div>
         <% end %>
       </li>

--- a/frontend/app/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_results.html.erb
@@ -92,10 +92,10 @@
 
         <% if show_edit_actions %>
         <td>
-          <div class="btn-group pull-right">
-            <%= link_to I18n.t("actions.view"), {:controller => :resolver, :action => :resolve_readonly, :uri => container_json["uri"]}, :class => "btn btn-xs btn-default" %>
+          <div class="btn-group ml-auto bg-white border rounded">
+            <%= link_to I18n.t("actions.view"), {:controller => :resolver, :action => :resolve_readonly, :uri => container_json["uri"]}, :class => "btn" %>
             <% if can_edit %>
-              <%= link_to I18n.t("actions.edit"), {:controller => :resolver, :action => :resolve_edit, :uri => container_json["uri"]}, :class => "btn btn-xs btn-primary" %>
+              <%= link_to I18n.t("actions.edit"), {:controller => :resolver, :action => :resolve_edit, :uri => container_json["uri"]}, :class => "btn btn-primary" %>
             <% end %>
           </div>
         </td>


### PR DESCRIPTION
# Summary
upgrades the view accessions page from bootstrap 3 to 4

# Related
https://gitlab.com/notch8/archivesspace/-/issues/17

# Video

https://user-images.githubusercontent.com/73361970/183769429-c7337264-3b19-4cb6-b12b-5ae1fca36426.mp4

# Acceptance Criteria
- [ ] The Accessions-View page looks closer to what it did in bootstrap 3
