### PR TITLE
Replace several bs5 classes

### DIFF
--- a/frontend/app/assets/javascripts/jobs.crud.js
+++ b/frontend/app/assets/javascripts/jobs.crud.js
@@ -75,7 +75,7 @@ var init = function () {
       initListing(code);
       $('.select-report').hide();
       $('.unselect-report').show();
-      $('.unselect-report-group').addClass('ml-auto');
+      $('.unselect-report-group').addClass('ms-auto');
       $('.create-report-template').show();
       $('.report-listing:not(#' + code + ')').hide();
       $('#format').show();
@@ -90,7 +90,7 @@ var init = function () {
       $('#report-fields').empty();
       $('.select-report').show();
       $('.unselect-report').hide();
-      $('.unselect-report-group').removeClass('ml-auto');
+      $('.unselect-report-group').removeClass('ms-auto');
       $('.create-report-template').hide();
       $('.report-listing').show();
       $('#format').hide();

--- a/frontend/app/assets/javascripts/largetree.js.erb
+++ b/frontend/app/assets/javascripts/largetree.js.erb
@@ -738,7 +738,7 @@
                 var title = row.find('.title');
                 var strippedTitle = $("<div>").html(node.title).text();
                 title.append($('<a class="record-title" />').prop('href', TreeIds.link_url(node.uri)).text(node.title));
-                button.append($('<span class="sr-only" />').text(strippedTitle));
+                button.append($('<span class="visually-hidden" />').text(strippedTitle));
                 title.attr('title', strippedTitle);
 
                 var ex = row.find('.expandme');

--- a/frontend/app/assets/javascripts/subrecord.crud.js.erb
+++ b/frontend/app/assets/javascripts/subrecord.crud.js.erb
@@ -44,7 +44,7 @@ $(function () {
 
           var addRemoveButton = function () {
             var removeBtn = $(
-              "<a href='javascript:void(0)' class='btn btn-default btn-xs float-right subrecord-form-remove' title='<%= I18n.t('resource._frontend.remove_subrecord') %>' aria-label='<%= I18n.t('resource._frontend.remove_subrecord') %>'><span class='glyphicon glyphicon-remove'></span></a>"
+              "<a href='javascript:void(0)' class='btn btn-default btn-xs float-end subrecord-form-remove' title='<%= I18n.t('resource._frontend.remove_subrecord') %>' aria-label='<%= I18n.t('resource._frontend.remove_subrecord') %>'><span class='glyphicon glyphicon-remove'></span></a>"
             );
             $subform.prepend(removeBtn);
             removeBtn.on('click', function () {

--- a/frontend/app/helpers/application_helper.rb
+++ b/frontend/app/helpers/application_helper.rb
@@ -119,7 +119,7 @@ module ApplicationHelper
 
     label = opts[:label] || I18n.t("help.icon")
 
-    label_text = "<span class='sr-only'> Visit the " + I18n.t("help.help_center") + "</span>"
+    label_text = "<span class='visually-hidden'> Visit the " + I18n.t("help.help_center") + "</span>"
 
     title = (opts.has_key? :topic) ? I18n.t("help.topics.#{opts[:topic]}", :default => I18n.t("help.default_tooltip", :default => "")) : I18n.t("help.default_tooltip", :default => "")
 

--- a/frontend/app/helpers/aspace_form_helper.rb
+++ b/frontend/app/helpers/aspace_form_helper.rb
@@ -525,7 +525,7 @@ module AspaceFormHelper
       prefix << "#{opts[:contextual]}." if opts[:contextual]
       prefix << 'plugins.' if opts[:plugin]
 
-      classes << 'control-label text-right'
+      classes << 'control-label text-end'
 
       options = {:class => classes.join(' '), :for => id_for(name)}
 

--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -213,7 +213,7 @@ module SearchHelper
 
   def add_multiselect_column
     @allow_multiselect = true
-    header = ('<label for="select_all" class="sr-only">' +
+    header = ('<label for="select_all" class="visually-hidden">' +
       I18n.t("search_results.selected") + '</label>' +
       check_box_tag("select_all", 1, false, "autocomplete" => "off")).html_safe
 
@@ -295,7 +295,7 @@ module SearchHelper
   end
 
   def sr_only(text)
-    ('<span class="sr-only">' + text + '</span>').html_safe
+    ('<span class="visually-hidden">' + text + '</span>').html_safe
   end
 
   def add_columns

--- a/frontend/app/views/accession_links/_accession_linker.html.erb
+++ b/frontend/app/views/accession_links/_accession_linker.html.erb
@@ -29,7 +29,7 @@
       />
 
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="Link to record"><span class="caret"></span></a>
+        <a class="btn btn-default dropdown-toggle last" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="Link to record"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
         </ul>

--- a/frontend/app/views/accessions/_linker.html.erb
+++ b/frontend/app/views/accessions/_linker.html.erb
@@ -54,7 +54,7 @@
           />
           
           <div class="input-group-btn">
-           <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t('accession.linker.link_title') %>" aria-label="<%= I18n.t('accession.linker.link_title') %>"><span class="caret"></span></a>
+           <a class="btn btn-default dropdown-toggle last" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t('accession.linker.link_title') %>" aria-label="<%= I18n.t('accession.linker.link_title') %>"><span class="caret"></span></a>
            <ul class="dropdown-menu">
              <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
            </ul>

--- a/frontend/app/views/accessions/_toolbar.html.erb
+++ b/frontend/app/views/accessions/_toolbar.html.erb
@@ -34,7 +34,7 @@
                   <%= I18n.t "actions.spawn" %>
                   <span class="caret"></span>
                 </a>
-                <ul class="dropdown-menu pr-3">
+                <ul class="dropdown-menu pe-3">
                   <li class='dropdown-item'>
                     <%= link_to "<span class='icomoon icon-accession'></span> #{I18n.t("accession._singular")}".html_safe, :controller => :accessions, :action => :new, :accession_id => @accession.id %>
                   </li>

--- a/frontend/app/views/accessions/_toolbar.html.erb
+++ b/frontend/app/views/accessions/_toolbar.html.erb
@@ -30,7 +30,7 @@
             <% end %>
             <% if not @accession.suppressed %>
               <div id="spawn-dropdown" class="btn btn-inline-form border-left">
-                <a class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);">
+                <a class="btn btn-sm btn-default dropdown-toggle" data-bs-toggle="dropdown" href="javascript:void(0);">
                   <%= I18n.t "actions.spawn" %>
                   <span class="caret"></span>
                 </a>
@@ -60,7 +60,7 @@
               <% end %>
             </div>
             <div class="btn-group dropdown border-left" id="other-dropdown">
-              <a class="btn btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+              <a class="btn btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <%= I18n.t('actions.more') %>
                 <span class="caret"></span>
               </a>

--- a/frontend/app/views/accessions/_toolbar.html.erb
+++ b/frontend/app/views/accessions/_toolbar.html.erb
@@ -20,7 +20,7 @@
             <%= I18n.t("actions.toolbar_disabled_message") %>
           </div>
         <% end %>
-        <div class="d-flex ml-auto">
+        <div class="d-flex ms-auto">
           <div class="btn-group align-items-center bg-white rounded border">
             <% if AppConfig[:enable_public] %>
               <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => @accession} %>
@@ -109,7 +109,7 @@
               <% end %>
             </div>
           <% end %>
-        </div><!-- btn-toolbar ml-auto -->
+        </div><!-- btn-toolbar ms-auto -->
         <div class="clearfix"></div>
       </div><!-- record-toolbar -->
     </div><!-- col-md-12 -->

--- a/frontend/app/views/accessions/_toolbar.html.erb
+++ b/frontend/app/views/accessions/_toolbar.html.erb
@@ -29,7 +29,7 @@
               <%= render_aspace_partial :partial => "shared/event_dropdown", :locals => {:record => @accession } %>
             <% end %>
             <% if not @accession.suppressed %>
-              <div id="spawn-dropdown" class="btn btn-inline-form border-left">
+              <div id="spawn-dropdown" class="btn btn-inline-form border-start">
                 <a class="btn btn-sm btn-default dropdown-toggle" data-bs-toggle="dropdown" href="javascript:void(0);">
                   <%= I18n.t "actions.spawn" %>
                   <span class="caret"></span>
@@ -47,7 +47,7 @@
                 </ul>
               </div>
             <% end %>
-            <div class='border-left'>
+            <div class='border-start'>
               <% if user_can?('transfer_archival_record') %>
                 <%=
                   render_aspace_partial :partial => "shared/transfer_dropdown",
@@ -59,7 +59,7 @@
                 %>
               <% end %>
             </div>
-            <div class="btn-group dropdown border-left" id="other-dropdown">
+            <div class="btn-group dropdown border-start" id="other-dropdown">
               <a class="btn btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <%= I18n.t('actions.more') %>
                 <span class="caret"></span>

--- a/frontend/app/views/accessions/index.html.erb
+++ b/frontend/app/views/accessions/index.html.erb
@@ -9,7 +9,7 @@
   <div class="col-md-9">
     <% if user_can?('update_accession_record') %>
       <div class="record-toolbar d-flex align-items-center">
-        <div class="btn-group ml-auto border bg-white">
+        <div class="btn-group ms-auto border bg-white">
           <% if user_can?('manage_repository') %>
               <%= link_to I18n.t("actions.edit_default_values"), {:controller => :accessions, :action => :defaults}, :class => "btn btn-sm btn-default" %>
           <% end %>

--- a/frontend/app/views/agents/_linker.html.erb
+++ b/frontend/app/views/agents/_linker.html.erb
@@ -70,7 +70,7 @@
       <% end %>
 
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center justify-content-center" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Link to subject" id="dropdownMenuAgentsToggle">
+        <a class="btn btn-default dropdown-toggle last border-dark border-start-0 d-flex align-items-center justify-content-center" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Link to subject" id="dropdownMenuAgentsToggle">
         </a>
         <ul class="dropdown-menu dropdown-menu-right" id='dropdownMenuAgents' aria-labelledby="#dropdownMenuAgents">
           <li class='dropdown-item'>

--- a/frontend/app/views/agents/_linker.html.erb
+++ b/frontend/app/views/agents/_linker.html.erb
@@ -70,7 +70,7 @@
       <% end %>
 
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center justify-content-center" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Link to subject" id="dropdownMenuAgentsToggle">
+        <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center justify-content-center" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Link to subject" id="dropdownMenuAgentsToggle">
         </a>
         <ul class="dropdown-menu dropdown-menu-right" id='dropdownMenuAgents' aria-labelledby="#dropdownMenuAgents">
           <li class='dropdown-item'>

--- a/frontend/app/views/agents/_linker.html.erb
+++ b/frontend/app/views/agents/_linker.html.erb
@@ -72,7 +72,7 @@
       <div class="input-group-btn">
         <a class="btn btn-default dropdown-toggle last border-dark border-start-0 d-flex align-items-center justify-content-center" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Link to subject" id="dropdownMenuAgentsToggle">
         </a>
-        <ul class="dropdown-menu dropdown-menu-right" id='dropdownMenuAgents' aria-labelledby="#dropdownMenuAgents">
+        <ul class="dropdown-menu dropdown-menu-end" id='dropdownMenuAgents' aria-labelledby="#dropdownMenuAgents">
           <li class='dropdown-item'>
             <a href="javascript:void(0);" class="linker-browse-btn">
               <%= I18n.t("actions.browse") %>

--- a/frontend/app/views/agents/_linker.html.erb
+++ b/frontend/app/views/agents/_linker.html.erb
@@ -22,7 +22,7 @@
   end
 %>
 <div class="form-group <% if required %> required <% end %> row">
-  <label class="control-label col-sm-2 text-right"
+  <label class="control-label col-sm-2 text-end"
          id="<%= form.id_for("ref") %>_label"
          for="<%= form.id_for("ref") %>">
     <%= wrap_with_tooltip(linker_label, "related_agent.related_agent_tooltip", "control-label initialised") %>

--- a/frontend/app/views/agents/_merge_dropdown.html.erb
+++ b/frontend/app/views/agents/_merge_dropdown.html.erb
@@ -36,7 +36,7 @@
                                      :"data-confirm-btn-class" => "btn btn-default"
                                    })
           %>
-          <a class="btn btn-cancel btn-default ml-auto border" href="#"><%= I18n.t("actions.cancel") %></a>
+          <a class="btn btn-cancel btn-default ms-auto border" href="#"><%= I18n.t("actions.cancel") %></a>
         </div>
         <% end %>
       </li>

--- a/frontend/app/views/agents/_merge_dropdown.html.erb
+++ b/frontend/app/views/agents/_merge_dropdown.html.erb
@@ -5,7 +5,7 @@
 %>
 
   <div id="merge-dropdown" class="btn-group dropdown" data-no-change-tracking="true">
-    <a class="btn btn-sm btn-default dropdown-toggle merge-action" data-toggle="dropdown" href="#" title="<%= I18n.t("actions.merge") %>">
+    <a class="btn btn-sm btn-default dropdown-toggle merge-action" data-bs-toggle="dropdown" href="#" title="<%= I18n.t("actions.merge") %>">
       <%= I18n.t("actions.merge") %> <span class="caret"></span>
     </a>
     <ul class="dropdown-menu merge-form dropdown-menu-right">

--- a/frontend/app/views/agents/_merge_dropdown.html.erb
+++ b/frontend/app/views/agents/_merge_dropdown.html.erb
@@ -8,7 +8,7 @@
     <a class="btn btn-sm btn-default dropdown-toggle merge-action" data-bs-toggle="dropdown" href="#" title="<%= I18n.t("actions.merge") %>">
       <%= I18n.t("actions.merge") %> <span class="caret"></span>
     </a>
-    <ul class="dropdown-menu merge-form dropdown-menu-right">
+    <ul class="dropdown-menu merge-form dropdown-menu-end">
       <li>
       <p><%= I18n.t("#{singular}._frontend.messages.merge_description") %>   <%= record.title %></p>
         <%= form_context :merge, {} do |form| %>

--- a/frontend/app/views/agents/_merge_selector.html.erb
+++ b/frontend/app/views/agents/_merge_selector.html.erb
@@ -2,9 +2,9 @@
 
 <div class="form-actions row mb-3">
   <div class='col d-flex'>
-    <button type="button" class="btn preview-merge btn bg-white border mr-2"><%= I18n.t("agent._frontend.action.preview") %></button>
+    <button type="button" class="btn preview-merge btn bg-white border me-2"><%= I18n.t("agent._frontend.action.preview") %></button>
     <button type="button" class="btn btn-primary do-merge"><%= I18n.t("actions.merge") %></button>
-    <%= link_to I18n.t("actions.cancel"), {:controller => :agents, :action => :show, :id => @agent.id}, :class => "btn btn-cancel btn-default ml-auto bg-white border" %>
+    <%= link_to I18n.t("actions.cancel"), {:controller => :agents, :action => :show, :id => @agent.id}, :class => "btn btn-cancel btn-default ms-auto bg-white border" %>
   </div>
 </div>
 <div id="merge-selector-root" class="row">
@@ -451,5 +451,5 @@
 <div class="form-actions row p-3">
   <button type="button" class="btn preview-merge"><%= I18n.t("agent._frontend.action.preview") %></button>
   <button type="button" class="btn btn-primary do-merge"><%= I18n.t("actions.merge") %></button>
-  <%= link_to I18n.t("actions.cancel"), {:controller => :agents, :action => :show, :id => @agent.id}, :class => "btn btn-cancel btn-default pull-right ml-auto border bg-white" %>
+  <%= link_to I18n.t("actions.cancel"), {:controller => :agents, :action => :show, :id => @agent.id}, :class => "btn btn-cancel btn-default pull-right ms-auto border bg-white" %>
 </div>

--- a/frontend/app/views/agents/_toolbar.html.erb
+++ b/frontend/app/views/agents/_toolbar.html.erb
@@ -14,18 +14,18 @@
     <div class="btn-toolbar ml-auto bg-white border">
       <div class="btn-group align-items-center">
         <% if edit_mode? && full_mode? %>
-          <div class="border-right">
+          <div class="border-end">
             <%= render_aspace_partial :partial => "shared/lightmode_toggle", :locals => {:type => 'agents'} %>
           </div>
         <% end %>
 
         <% if user_can?('update_event_record')  %>
-          <div class="btn-group border-right">
+          <div class="btn-group border-end">
             <%= render_aspace_partial :partial => "shared/event_dropdown", :locals => {:record => @agent} %>
           </div>
         <% end %>
 
-        <div class="btn-group right border-right">
+        <div class="btn-group right border-end">
           <%= button_confirm_action(I18n.t("actions.publish"),
                       url_for({:action => :publish, :id => @agent.id}),
                       {
@@ -38,17 +38,17 @@
         </div>
 
         <% if AppConfig[:enable_public] %>
-          <div class="border-right">
+          <div class="border-end">
             <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => @agent} %>
           </div>
         <% end %>
 
         <% unless @agent.agent_type.to_s == "agent_software" %>
-          <div class="btn btn-inline-form border-right">
+          <div class="btn btn-inline-form border-end">
             <%= link_to I18n.t("actions.export_eac"), {:controller => :exports, :action => :download_eac, :id => @agent.id, :type => @agent.  agent_type}, :class => "btn btn-sm btn-default" %>
           </div>
 
-          <div class="btn btn-inline-form border-right">
+          <div class="btn btn-inline-form border-end">
             <%= link_to I18n.t("actions.export_marc_auth"), {:controller => :exports, :action => :download_marc_auth, :id => @agent.id, :type => @agent.agent_type}, :class => "btn btn-sm btn-default" %>
           </div>
         <% end %>

--- a/frontend/app/views/agents/_toolbar.html.erb
+++ b/frontend/app/views/agents/_toolbar.html.erb
@@ -11,7 +11,7 @@
       </div>
     <% end %>
 
-    <div class="btn-toolbar ml-auto bg-white border">
+    <div class="btn-toolbar ms-auto bg-white border">
       <div class="btn-group align-items-center">
         <% if edit_mode? && full_mode? %>
           <div class="border-end">

--- a/frontend/app/views/agents/index.html.erb
+++ b/frontend/app/views/agents/index.html.erb
@@ -12,7 +12,7 @@
         <div class="btn-group ml-auto bg-white border">
           <% if user_can?('manage_repository') %>
             <div class="btn-group border-right">
-              <a class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);">
+              <a class="btn btn-sm btn-default dropdown-toggle" data-bs-toggle="dropdown" href="javascript:void(0);">
                 <%= I18n.t("actions.edit_required_fields") %>
               </a>
               <ul class="dropdown-menu">
@@ -24,7 +24,7 @@
               </ul>
             </div>
             <div class="btn-group">
-              <a class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);">
+              <a class="btn btn-sm btn-default dropdown-toggle" data-bs-toggle="dropdown" href="javascript:void(0);">
                 <%= I18n.t("actions.edit_default_values") %>
               </a>
               <ul class="dropdown-menu">
@@ -38,7 +38,7 @@
 
           <div class="btn-group">
             <%= link_to I18n.t("actions.export_csv"), request.parameters.merge({ :format => :csv, :fields => fields}), id: "searchExport",  class:  "btn btn-sm btn-info" %>
-            <a class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" href="#">
+            <a class="btn btn-sm btn-default dropdown-toggle" data-bs-toggle="dropdown" href="#">
               <%= I18n.t("agent._frontend.action.create") %>
             </a>
             <ul class="dropdown-menu">

--- a/frontend/app/views/agents/index.html.erb
+++ b/frontend/app/views/agents/index.html.erb
@@ -9,7 +9,7 @@
   <div class="col-md-9">
     <% if user_can?('update_agent_record') %>
       <div class="record-toolbar d-flex align-items-center">
-        <div class="btn-group ml-auto bg-white border">
+        <div class="btn-group ms-auto bg-white border">
           <% if user_can?('manage_repository') %>
             <div class="btn-group border-end">
               <a class="btn btn-sm btn-default dropdown-toggle" data-bs-toggle="dropdown" href="javascript:void(0);">

--- a/frontend/app/views/agents/index.html.erb
+++ b/frontend/app/views/agents/index.html.erb
@@ -11,7 +11,7 @@
       <div class="record-toolbar d-flex align-items-center">
         <div class="btn-group ml-auto bg-white border">
           <% if user_can?('manage_repository') %>
-            <div class="btn-group border-right">
+            <div class="btn-group border-end">
               <a class="btn btn-sm btn-default dropdown-toggle" data-bs-toggle="dropdown" href="javascript:void(0);">
                 <%= I18n.t("actions.edit_required_fields") %>
               </a>

--- a/frontend/app/views/archival_objects/_toolbar_new_records.html.erb
+++ b/frontend/app/views/archival_objects/_toolbar_new_records.html.erb
@@ -2,7 +2,7 @@
   <div class="save-changes">
     <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
   </div>
-  <div class="btn-toolbar ml-auto select-resource">
+  <div class="btn-toolbar ms-auto select-resource">
     <div class="btn-group">
       <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.select_resource") %></button>
     </div>

--- a/frontend/app/views/assessment_attributes/edit.html.erb
+++ b/frontend/app/views/assessment_attributes/edit.html.erb
@@ -60,7 +60,7 @@
                       <span class="input-group-btn">
                         <button class="btn btn-danger remove-repo-attribute">
                           <span class="glyphicon glyphicon-remove"></span>
-                          <span class="sr-only"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_rating", :rating_type =>rating.fetch('label')) %></span>
+                          <span class="visually-hidden"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_rating", :rating_type =>rating.fetch('label')) %></span>
                         </button>
                       </span>
                     </div>
@@ -75,7 +75,7 @@
                 <td colspan="2">
                   <button class="btn btn-sm btn-success add-repo-attribute" data-type="rating">
                     <span class="glyphicon glyphicon-plus"></span>
-                    <span class="sr-only"><%= I18n.t("assessment_attribute_definitions._frontend.action.add_type", :type => I18n.t('assessment_attribute_definitions._frontend.section.ratings')) %></span>
+                    <span class="visually-hidden"><%= I18n.t("assessment_attribute_definitions._frontend.action.add_type", :type => I18n.t('assessment_attribute_definitions._frontend.section.ratings')) %></span>
                   </button>
                 </td>
               </tr>
@@ -129,7 +129,7 @@
                       <span class="input-group-btn">
                         <button class="btn btn-danger remove-repo-attribute">
                           <span class="glyphicon glyphicon-remove"></span>
-                          <span class="sr-only"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_format", :format_type =>format.fetch('label')) %></span>
+                          <span class="visually-hidden"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_format", :format_type =>format.fetch('label')) %></span>
                         </button>
                       </span>
                     </div>
@@ -144,7 +144,7 @@
                 <td colspan="2">
                   <button class="btn btn-sm btn-success add-repo-attribute" data-type="format">
                     <span class="glyphicon glyphicon-plus"></span>
-                    <span class="sr-only"><%= I18n.t("assessment_attribute_definitions._frontend.action.add_type", :type => I18n.t('assessment_attribute_definitions._frontend.section.formats')) %></span>
+                    <span class="visually-hidden"><%= I18n.t("assessment_attribute_definitions._frontend.action.add_type", :type => I18n.t('assessment_attribute_definitions._frontend.section.formats')) %></span>
                   </button>
                 </td>
               </tr>
@@ -198,7 +198,7 @@
                       <span class="input-group-btn">
                         <button class="btn btn-danger remove-repo-attribute">
                           <span class="glyphicon glyphicon-remove"></span>
-                          <span class="sr-only"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_issue", :issue_type =>conservation_issue.fetch('label')) %></span>
+                          <span class="visually-hidden"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_issue", :issue_type =>conservation_issue.fetch('label')) %></span>
                         </button>
                       </span>
                     </div>
@@ -213,7 +213,7 @@
                 <td colspan="2">
                   <button class="btn btn-sm btn-success add-repo-attribute" data-type="conservation_issue">
                     <span class="glyphicon glyphicon-plus"></span>
-                    <span class="sr-only"><%= I18n.t("assessment_attribute_definitions._frontend.action.add_type", :type => I18n.t('assessment_attribute_definitions._frontend.section.conservation_issues')) %></span>
+                    <span class="visually-hidden"><%= I18n.t("assessment_attribute_definitions._frontend.action.add_type", :type => I18n.t('assessment_attribute_definitions._frontend.section.conservation_issues')) %></span>
                   </button>
                 </td>
               </tr>
@@ -243,7 +243,7 @@
         <span class="input-group-btn">
           <button class="btn btn-danger remove-repo-attribute">
             <span class="glyphicon glyphicon-remove"></span>
-            <span class="sr-only"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_rating", :rating_type =>'') %></span>
+            <span class="visually-hidden"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_rating", :rating_type =>'') %></span>
           </button>
         </span>
       </div>
@@ -261,7 +261,7 @@
         <span class="input-group-btn">
           <button class="btn btn-danger remove-repo-attribute">
             <span class="glyphicon glyphicon-remove"></span>
-            <span class="sr-only"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_format", :format_type =>'') %></span>
+            <span class="visually-hidden"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_format", :format_type =>'') %></span>
           </button>
         </span>
       </div>
@@ -279,7 +279,7 @@
         <span class="input-group-btn">
           <button class="btn btn-danger remove-repo-attribute">
             <span class="glyphicon glyphicon-remove"></span>
-            <span class="sr-only"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_issue", :issue_type =>'') %></span>
+            <span class="visually-hidden"><%= I18n.t("assessment_attribute_definitions._frontend.action.remove_issue", :issue_type =>'') %></span>
           </button>
         </span>
       </div>

--- a/frontend/app/views/assessments/_agent_linker.html.erb
+++ b/frontend/app/views/assessments/_agent_linker.html.erb
@@ -31,7 +31,7 @@
     />
 
     <div class="input-group-btn">
-      <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t('agent.linker.link_title') %>"><span class="caret"></span></a>
+      <a class="btn btn-default dropdown-toggle last" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t('agent.linker.link_title') %>"><span class="caret"></span></a>
       <ul class="dropdown-menu">
         <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
       </ul>

--- a/frontend/app/views/assessments/_embedded.html.erb
+++ b/frontend/app/views/assessments/_embedded.html.erb
@@ -10,7 +10,7 @@
 <section id="<%= section_id %>" class="subrecord-form-dummy">
   <h3 class="subrecord-form-heading d-flex align-items-center">
     <%= heading_text %>
-    <%= link_to I18n.t("actions.view_search_results"), html_search_url, :class => "btn ml-auto border rounded bg-white btn-sm m-2" %>
+    <%= link_to I18n.t("actions.view_search_results"), html_search_url, :class => "btn ms-auto border rounded bg-white btn-sm m-2" %>
   </h3>
   <div class="subrecord-form-container">
     <div class="subrecord-form-fields embedded-search" data-url="<%= ajax_search_url %>">

--- a/frontend/app/views/assessments/_form.html.erb
+++ b/frontend/app/views/assessments/_form.html.erb
@@ -48,7 +48,7 @@
       <%= I18n.t "assessment._frontend.section.basic_information" %>
     </h3>
     <fieldset>
-      <legend class='sr-only'><%= I18n.t "assessment._frontend.section.basic_information" %></legend>
+      <legend class='visually-hidden'><%= I18n.t "assessment._frontend.section.basic_information" %></legend>
 
       <%= render_plugin_partials("top_of_basic_information_assessments",
                                  :form => form,
@@ -232,7 +232,7 @@
       <%= I18n.t "assessment._frontend.section.rating_attributes" %>
     </h3>
     <fieldset>
-      <legend class='sr-only'><%= I18n.t "assessment._frontend.section.rating_attributes" %></legend>
+      <legend class='visually-hidden'><%= I18n.t "assessment._frontend.section.rating_attributes" %></legend>
       <div class="subrecord-form-container">
         <div class="subrecord-form-fields">
           <%= form.label_and_textarea 'general_assessment_note' %>
@@ -266,14 +266,14 @@
             <table id="rating_attributes_table" class="table table-bordered table-hover">
               <thead>
                 <tr>
-                  <th class="col-sm-5"><span class="sr-only">Condition</span></th>
+                  <th class="col-sm-5"><span class="visually-hidden">Condition</span></th>
                   <th class="col-sm-1 text-center"><%= I18n.t('assessment.rating_attributes_value.rating_none') %></th>
                   <th class="col-sm-1 text-center"><%= I18n.t('assessment.rating_attributes_value.rating_1') %></th>
                   <th class="col-sm-1 text-center"><%= I18n.t('assessment.rating_attributes_value.rating_2') %></th>
                   <th class="col-sm-1 text-center"><%= I18n.t('assessment.rating_attributes_value.rating_3') %></th>
                   <th class="col-sm-1 text-center"><%= I18n.t('assessment.rating_attributes_value.rating_4') %></th>
                   <th class="col-sm-1 text-center"><%= I18n.t('assessment.rating_attributes_value.rating_5') %></th>
-                  <th><span class="sr-only">Add attribute note?</span></th>
+                  <th><span class="visually-hidden">Add attribute note?</span></th>
                 </tr>
               </thead>
               <tbody>
@@ -296,44 +296,44 @@
                                  data-html="true"
                                  title="<%= rating_values_tooltip %>"
                                  data-template='<div class="tooltip ratings-value-tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'>
-                                <span class='sr-only'><%= i18n_rating(rating.fetch('label')) %></span>
+                                <span class='visually-hidden'><%= i18n_rating(rating.fetch('label')) %></span>
                           </label>
                         <% end %>
                       </td>
                         <td class="text-center">
                           <label>
                             <%= form.radio('value', nil) %>
-                            <span class='sr-only'><%= I18n.t('assessment.rating_attributes_value.rating_none') %></span>
+                            <span class='visually-hidden'><%= I18n.t('assessment.rating_attributes_value.rating_none') %></span>
                           </label>
                         </td>
                         <td class="text-center">
                           <label>
                             <%= form.radio('value', '1') %>
-                            <span class='sr-only'><%= I18n.t('assessment.rating_attributes_value.rating_1') %></span>
+                            <span class='visually-hidden'><%= I18n.t('assessment.rating_attributes_value.rating_1') %></span>
                           </label>
                         </td>
                         <td class="text-center">
                           <label>
                             <%= form.radio('value', '2') %>
-                            <span class='sr-only'><%= I18n.t('assessment.rating_attributes_value.rating_2') %></span>
+                            <span class='visually-hidden'><%= I18n.t('assessment.rating_attributes_value.rating_2') %></span>
                           </label>
                         </td>
                         <td class="text-center">
                           <label>
                             <%= form.radio('value', '3') %>
-                            <span class='sr-only'><%= I18n.t('assessment.rating_attributes_value.rating_3') %></span>
+                            <span class='visually-hidden'><%= I18n.t('assessment.rating_attributes_value.rating_3') %></span>
                           </label>
                         </td>
                         <td class="text-center">
                           <label>
                             <%= form.radio('value', '4') %>
-                            <span class='sr-only'><%= I18n.t('assessment.rating_attributes_value.rating_4') %></span>
+                            <span class='visually-hidden'><%= I18n.t('assessment.rating_attributes_value.rating_4') %></span>
                           </label>
                         </td>
                         <td class="text-center">
                           <label>
                             <%= form.radio('value', '5') %>
-                            <span class='sr-only'><%= I18n.t('assessment.rating_attributes_value.rating_5') %></span>
+                            <span class='visually-hidden'><%= I18n.t('assessment.rating_attributes_value.rating_5') %></span>
                           </label>
                         </td>
                         <td>
@@ -403,44 +403,44 @@
                                    data-html="true"
                                    title="<%= rating_values_tooltip %>"
                                    data-template='<div class="tooltip ratings-value-tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'>
-                                   <span class='sr-only'><%= i18n_rating(rating.fetch('label')) %></span>
+                                   <span class='visually-hidden'><%= i18n_rating(rating.fetch('label')) %></span>
                             </label>
                           <% end %>
                         </td>
                           <td class="text-center">
                             <label>
                               <%= form.radio('value', nil) %>
-                              <span class='sr-only'><%= I18n.t('assessment.rating_attributes_value.rating_none') %></span>
+                              <span class='visually-hidden'><%= I18n.t('assessment.rating_attributes_value.rating_none') %></span>
                             </label>
                           </td>
                           <td class="text-center">
                             <label>
                               <%= form.radio('value', '1') %>
-                              <span class='sr-only'><%= I18n.t('assessment.rating_attributes_value.rating_1') %></span>
+                              <span class='visually-hidden'><%= I18n.t('assessment.rating_attributes_value.rating_1') %></span>
                             </label>
                           </td>
                           <td class="text-center">
                             <label>
                               <%= form.radio('value', '2') %>
-                              <span class='sr-only'><%= I18n.t('assessment.rating_attributes_value.rating_2') %></span>
+                              <span class='visually-hidden'><%= I18n.t('assessment.rating_attributes_value.rating_2') %></span>
                             </label>
                           </td>
                           <td class="text-center">
                             <label>
                               <%= form.radio('value', '3') %>
-                              <span class='sr-only'><%= I18n.t('assessment.rating_attributes_value.rating_3') %></span>
+                              <span class='visually-hidden'><%= I18n.t('assessment.rating_attributes_value.rating_3') %></span>
                             </label>
                           </td>
                           <td class="text-center">
                             <label>
                               <%= form.radio('value', '4') %>
-                              <span class='sr-only'><%= I18n.t('assessment.rating_attributes_value.rating_4') %></span>
+                              <span class='visually-hidden'><%= I18n.t('assessment.rating_attributes_value.rating_4') %></span>
                             </label>
                           </td>
                           <td class="text-center">
                             <label>
                               <%= form.radio('value', '5') %>
-                              <span class='sr-only'><%= I18n.t('assessment.rating_attributes_value.rating_5') %></span>
+                              <span class='visually-hidden'><%= I18n.t('assessment.rating_attributes_value.rating_5') %></span>
                             </label>
                           </td>
                           <td>
@@ -488,7 +488,7 @@
       <%= I18n.t "assessment._frontend.section.format_attributes" %>
     </h3>
     <fieldset>
-      <legend class='sr-only'><%= I18n.t "assessment._frontend.section.format_attributes" %></legend>
+      <legend class='visually-hidden'><%= I18n.t "assessment._frontend.section.format_attributes" %></legend>
       <div class="subrecord-form-container">
         <div class="subrecord-form-fields">
           <% if form.readonly? %>
@@ -599,7 +599,7 @@
       <%= I18n.t "assessment._frontend.section.conservation_issue_attributes" %>
     </h3>
     <fieldset>
-      <legend class='sr-only'><%= I18n.t "assessment._frontend.section.conservation_issue_attributes" %></legend>
+      <legend class='visually-hidden'><%= I18n.t "assessment._frontend.section.conservation_issue_attributes" %></legend>
       <div class="subrecord-form-container">
         <div class="subrecord-form-fields">
           <% if form.readonly? %>

--- a/frontend/app/views/assessments/_records_linker.html.erb
+++ b/frontend/app/views/assessments/_records_linker.html.erb
@@ -29,7 +29,7 @@
     />
 
     <div class="input-group-btn">
-      <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t('assessment.linker.link_title') %>"><span class="caret"></span></a>
+      <a class="btn btn-default dropdown-toggle last" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t('assessment.linker.link_title') %>"><span class="caret"></span></a>
       <ul class="dropdown-menu">
         <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
       </ul>

--- a/frontend/app/views/assessments/index.html.erb
+++ b/frontend/app/views/assessments/index.html.erb
@@ -9,7 +9,7 @@
   <div class="col-md-9">
     <% if user_can?('update_assessment_record') %>
       <div class="record-toolbar d-flex align-items-center">
-        <div class="btn-group ml-auto bg-white border">
+        <div class="btn-group ms-auto bg-white border">
           <%= link_to I18n.t("actions.export_csv"), request.parameters.merge({ :format => :csv,
             :fields => fields}), id: "searchExport",  class:  "btn btn-sm btn-info" %>
           <% if user_can?("update_assessment_record") %>

--- a/frontend/app/views/bulk_import_templates/_listing.html.erb
+++ b/frontend/app/views/bulk_import_templates/_listing.html.erb
@@ -6,7 +6,7 @@
             <tr>
                 <th><%= I18n.t("bulk_import_template._singular") %></th>
                 <th></th>
-                <th width="70px"><span class="sr-only"><%= I18n.t('actions.download') %></span></th>
+                <th width="70px"><span class="visually-hidden"><%= I18n.t('actions.download') %></span></th>
             </tr>
         </thead>
         <tbody>

--- a/frontend/app/views/classification_terms/_linker.html.erb
+++ b/frontend/app/views/classification_terms/_linker.html.erb
@@ -68,7 +68,7 @@
           <% end %>
 
         <div class="input-group-btn">
-           <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t('classification_term.linker.link_title') %>" aria-label="<%= I18n.t('classification_term.linker.link_title') %>"><span class="caret"></span></a>
+           <a class="btn btn-default dropdown-toggle last" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t('classification_term.linker.link_title') %>" aria-label="<%= I18n.t('classification_term.linker.link_title') %>"><span class="caret"></span></a>
            <ul class="dropdown-menu">
              <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
            </ul>

--- a/frontend/app/views/classification_terms/_record_linker.html.erb
+++ b/frontend/app/views/classification_terms/_record_linker.html.erb
@@ -50,7 +50,7 @@
       <% end %>
 
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("linked_record.linker_ref.link_title") %>"><span class="caret"></span></a>
+        <a class="btn btn-default dropdown-toggle last" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("linked_record.linker_ref.link_title") %>"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
         </ul>

--- a/frontend/app/views/classifications/_linker.html.erb
+++ b/frontend/app/views/classifications/_linker.html.erb
@@ -67,7 +67,7 @@
           <% end %>
           
         <div class="input-group-btn">
-           <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("classification.linker.link_title") %>" aria-label="<%= I18n.t("classification.linker.link_title") %>"><span class="caret"></span></a>
+           <a class="btn btn-default dropdown-toggle last border-dark border-start-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("classification.linker.link_title") %>" aria-label="<%= I18n.t("classification.linker.link_title") %>"><span class="caret"></span></a>
            <ul class="dropdown-menu">
              <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
            </ul>

--- a/frontend/app/views/classifications/_linker.html.erb
+++ b/frontend/app/views/classifications/_linker.html.erb
@@ -67,7 +67,7 @@
           <% end %>
           
         <div class="input-group-btn">
-           <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center" data-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("classification.linker.link_title") %>" aria-label="<%= I18n.t("classification.linker.link_title") %>"><span class="caret"></span></a>
+           <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("classification.linker.link_title") %>" aria-label="<%= I18n.t("classification.linker.link_title") %>"><span class="caret"></span></a>
            <ul class="dropdown-menu">
              <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
            </ul>

--- a/frontend/app/views/classifications/_record_linker.html.erb
+++ b/frontend/app/views/classifications/_record_linker.html.erb
@@ -50,7 +50,7 @@
       <% end %>
 
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center" data-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("linked_record.linker_ref.link_title") %>"><span class="caret"></span></a>
+        <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("linked_record.linker_ref.link_title") %>"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
         </ul>

--- a/frontend/app/views/classifications/_record_linker.html.erb
+++ b/frontend/app/views/classifications/_record_linker.html.erb
@@ -50,7 +50,7 @@
       <% end %>
 
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("linked_record.linker_ref.link_title") %>"><span class="caret"></span></a>
+        <a class="btn btn-default dropdown-toggle last border-dark border-start-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("linked_record.linker_ref.link_title") %>"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
         </ul>

--- a/frontend/app/views/classifications/_toolbar.html.erb
+++ b/frontend/app/views/classifications/_toolbar.html.erb
@@ -16,7 +16,7 @@
         <%= I18n.t("actions.toolbar_disabled_message") %>
       </div>
     <% end %>
-    <div class="btn-toolbar ml-auto">
+    <div class="btn-toolbar ms-auto">
       <% if user_can?('delete_classification_record') %>
         <div class="btn-group">
           <div class="btn btn-inline-form">

--- a/frontend/app/views/classifications/index.html.erb
+++ b/frontend/app/views/classifications/index.html.erb
@@ -13,7 +13,7 @@
    <div class="col-md-9">
      <% if user_can?('update_classification_record') %>
        <div class="record-toolbar d-flex align-items-center">
-          <div class="btn-group align-items-baseline bg-white rounded border ml-auto">
+          <div class="btn-group align-items-baseline bg-white rounded border ms-auto">
             <% if user_can?('manage_repository') %>
               <div>
                 <a class="dropdown-toggle btn btn-sm px-2" data-bs-toggle="dropdown" href="javascript:void(0);">

--- a/frontend/app/views/classifications/index.html.erb
+++ b/frontend/app/views/classifications/index.html.erb
@@ -16,7 +16,7 @@
           <div class="btn-group align-items-baseline bg-white rounded border ml-auto">
             <% if user_can?('manage_repository') %>
               <div>
-                <a class="dropdown-toggle btn btn-sm px-2" data-toggle="dropdown" href="javascript:void(0);">
+                <a class="dropdown-toggle btn btn-sm px-2" data-bs-toggle="dropdown" href="javascript:void(0);">
                   <%= I18n.t("actions.edit_default_values") %>
                 </a>
                 <ul class="dropdown-menu pr-3">

--- a/frontend/app/views/classifications/index.html.erb
+++ b/frontend/app/views/classifications/index.html.erb
@@ -19,7 +19,7 @@
                 <a class="dropdown-toggle btn btn-sm px-2" data-bs-toggle="dropdown" href="javascript:void(0);">
                   <%= I18n.t("actions.edit_default_values") %>
                 </a>
-                <ul class="dropdown-menu pr-3">
+                <ul class="dropdown-menu pe-3">
                   <li class="dropdown-item"><%= link_to I18n.t("classification._singular"), {:controller => :classifications, :action => :defaults} %></li>
                   <li class="dropdown-item"> <%= link_to I18n.t("classification_term._singular"), {:controller => :classification_terms, :action => :defaults} %></li>
                 </ul>

--- a/frontend/app/views/component_links/_component_linker.html.erb
+++ b/frontend/app/views/component_links/_component_linker.html.erb
@@ -29,7 +29,7 @@
       />
 
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="Link to record"><span class="caret"></span></a>
+        <a class="btn btn-default dropdown-toggle last" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="Link to record"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
         </ul>

--- a/frontend/app/views/container_profiles/_linker.html.erb
+++ b/frontend/app/views/container_profiles/_linker.html.erb
@@ -43,7 +43,7 @@
              data-exclude='<%= exclude_ids.to_json %>'
       />
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("container_profile.linker.link_title") %>" aria-label="<%= I18n.t("container_profile.linker.link_title") %>"><span class="caret"></span></a>
+        <a class="btn btn-default dropdown-toggle last" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("container_profile.linker.link_title") %>" aria-label="<%= I18n.t("container_profile.linker.link_title") %>"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
           <% if allow_create && user_can?('update_container_profile_record') %>

--- a/frontend/app/views/container_profiles/_toolbar.html.erb
+++ b/frontend/app/views/container_profiles/_toolbar.html.erb
@@ -6,7 +6,7 @@
       </div>
     <% end %>
     <% if !['new', 'create'].include?(controller.action_name) %>
-      <div class="btn-toolbar ml-auto">
+      <div class="btn-toolbar ms-auto">
         <div class="btn-group">
           <div class="btn btn-inline-form">
             <%= button_delete_action url_for(:controller => :container_profiles, :action => :delete, :id => @container_profile.id ), { :"data-title" => I18n.t("actions.delete_confirm_title", :title => @container_profile.name) } unless @container_profile.id.nil? %>

--- a/frontend/app/views/container_profiles/index.html.erb
+++ b/frontend/app/views/container_profiles/index.html.erb
@@ -16,7 +16,7 @@
         <%= link_to I18n.t("actions.export_csv"), request.parameters.merge({ :format => :csv, :fields =>
           fields }), id: "searchExport", class: "btn btn-sm btn-info" %>
         <% if user_can?('update_container_profile_record') %>
-          <%= link_to I18n.t("container_profile._frontend.action.create"), {:controller => :container_profiles, :action => :new}, :class => "btn btn-sm border-right" %>
+          <%= link_to I18n.t("container_profile._frontend.action.create"), {:controller => :container_profiles, :action => :new}, :class => "btn btn-sm border-end" %>
         <% end %>
         <% if user_can?('manage_container_profile_record') %>
           <button id="batchMerge" class="btn btn-sm multiselect-enabled" disabled="disabled" data-multiselect="#tabledSearchResults"><%= I18n.t("actions.merge")%></button>

--- a/frontend/app/views/container_profiles/index.html.erb
+++ b/frontend/app/views/container_profiles/index.html.erb
@@ -12,7 +12,7 @@
   </div>
   <div class="col-md-9">
     <div class="record-toolbar d-flex align-items-center">
-      <div class="btn-group ml-auto bg-white border rounded">
+      <div class="btn-group ms-auto bg-white border rounded">
         <%= link_to I18n.t("actions.export_csv"), request.parameters.merge({ :format => :csv, :fields =>
           fields }), id: "searchExport", class: "btn btn-sm btn-info" %>
         <% if user_can?('update_container_profile_record') %>

--- a/frontend/app/views/custom_report_templates/_listing.html.erb
+++ b/frontend/app/views/custom_report_templates/_listing.html.erb
@@ -9,7 +9,7 @@
 					<%= sort_pointer(:name, params, '&#x25B2;').html_safe %>
 				</th>
 				<th><%= I18n.t("custom_report_template.description") %></th>
-				<th width="70px"><span class="sr-only"><%= I18n.t('search_results.actions') %></span></th>
+				<th width="70px"><span class="visually-hidden"><%= I18n.t('search_results.actions') %></span></th>
 			</tr>
 		</thead>
 		<tbody>

--- a/frontend/app/views/custom_report_templates/_toolbar.html.erb
+++ b/frontend/app/views/custom_report_templates/_toolbar.html.erb
@@ -15,7 +15,7 @@
     <%= I18n.t("actions.toolbar_disabled_message") %>
     </div>
   <% end %>
-    <div class="btn-toolbar ml-auto">
+    <div class="btn-toolbar ms-auto">
       <div class="btn-group">
         <% if ['edit', 'update', 'new', 'create'].include?(controller.action_name) %>
           <button class="btn btn-sm btn-success no-change-tracking" type="button" id="check_all" data-checked="<%= I18n.t("actions.check_all") %>" data-unchecked="<%= I18n.t("actions.uncheck_all") %>"><%= I18n.t("actions.check_all") %></button>

--- a/frontend/app/views/custom_report_templates/index.html.erb
+++ b/frontend/app/views/custom_report_templates/index.html.erb
@@ -5,7 +5,7 @@
 	<div class="col-md-9">
 
 		<div class="record-toolbar d-flex align-items-center">
-			<div class="btn-group ml-auto bg-white border rounded">
+			<div class="btn-group ms-auto bg-white border rounded">
 				<%= link_to I18n.t("custom_report_template._frontend.action.create"), {:controller => :custom_report_templates, :action => :new}, :class => "btn btn-sm" %>
 				<%= link_to_help :topic => "accession_basic_information" %>
 			</div>

--- a/frontend/app/views/date_calculator/_template.html.erb
+++ b/frontend/app/views/date_calculator/_template.html.erb
@@ -12,7 +12,7 @@
       <%= hidden_field_tag 'record_uri', record.uri %>
       <div class="row">
         <div class="col-sm-6">
-        <%= label_tag 'label', I18n.t('date.label'), :class => 'col-sm-2 control-label sr-only' %>
+        <%= label_tag 'label', I18n.t('date.label'), :class => 'col-sm-2 control-label visually-hidden' %>
           <%= select_tag 'label', options_for_select(label_options, 'creation'), :class => 'form-control' %>
         </div>
         <div class="col-sm-6">

--- a/frontend/app/views/digital_objects/_linker.html.erb
+++ b/frontend/app/views/digital_objects/_linker.html.erb
@@ -53,7 +53,7 @@
       <% end %>
       
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("digital_object.linker.link_title") %>" aria-label="<%= I18n.t("digital_object.linker.link_title") %>"><span class="caret"></span></a>
+        <a class="btn btn-default dropdown-toggle last" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("digital_object.linker.link_title") %>" aria-label="<%= I18n.t("digital_object.linker.link_title") %>"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
           <% if user_can?('update_digital_object_record') %>

--- a/frontend/app/views/digital_objects/_toolbar.html.erb
+++ b/frontend/app/views/digital_objects/_toolbar.html.erb
@@ -5,7 +5,7 @@
       <li><%= link_to I18n.t("actions.export_mods"), {:controller => :exports, :action => :download_mods, :id => @digital_object.id} %></li>
 
       <li class="dropdown-submenu" id="download-mets-dropdown" data-download-mets-url="<%= url_for(:controller => :exports, :action => :download_mets, :id => @digital_object.id, :dmd_scheme => "${dmd_scheme}")%>">
-         <a href="#" data-toggle="dropdown" class="menu-with-options download-mets-action" title="<%= I18n.t("actions.export_mets") %>"><%= I18n.t("actions.export_mets") %></a>
+         <a href="#" data-bs-toggle="dropdown" class="menu-with-options download-mets-action" title="<%= I18n.t("actions.export_mets") %>"><%= I18n.t("actions.export_mets") %></a>
          <div class="dropdown-menu" id="form_download_mets">
            <fieldset>
              <input type="hidden" name="id", value="<%= @digital_object.id %>" />

--- a/frontend/app/views/digital_objects/index.html.erb
+++ b/frontend/app/views/digital_objects/index.html.erb
@@ -10,7 +10,7 @@
   <div class="col-md-9">
     <% if user_can?('update_digital_object_record') %>
       <div class="record-toolbar d-flex">
-        <div class="btn-group pull-right ml-auto align-items-center">
+        <div class="btn-group pull-right ms-auto align-items-center">
           <% if user_can?('manage_repository') %>
             <div class="btn-group border">
               <a class="btn btn-sm dropdown-toggle bg-white" data-bs-toggle="dropdown" href="javascript:void(0);">

--- a/frontend/app/views/digital_objects/index.html.erb
+++ b/frontend/app/views/digital_objects/index.html.erb
@@ -17,7 +17,7 @@
                 <%= I18n.t("actions.edit_default_values") %>
                 <span class="caret"></span>
               </a>
-              <ul class="dropdown-menu dropdown-menu-right">
+              <ul class="dropdown-menu dropdown-menu-end">
                 <li class='dropdown-item'><%= link_to I18n.t("digital_object._singular"), {:controller => :digital_objects, :action => :defaults} %></li>
                 <li class='dropdown-item'> <%= link_to I18n.t("digital_object_component._singular"), {:controller => :digital_object_components, :action => :defaults} %></li>
               </ul>

--- a/frontend/app/views/digital_objects/index.html.erb
+++ b/frontend/app/views/digital_objects/index.html.erb
@@ -13,7 +13,7 @@
         <div class="btn-group pull-right ml-auto align-items-center">
           <% if user_can?('manage_repository') %>
             <div class="btn-group border">
-              <a class="btn btn-sm dropdown-toggle bg-white" data-toggle="dropdown" href="javascript:void(0);">
+              <a class="btn btn-sm dropdown-toggle bg-white" data-bs-toggle="dropdown" href="javascript:void(0);">
                 <%= I18n.t("actions.edit_default_values") %>
                 <span class="caret"></span>
               </a>

--- a/frontend/app/views/enumerations/index.html.erb
+++ b/frontend/app/views/enumerations/index.html.erb
@@ -3,7 +3,7 @@
 <div class="row">
   <div class="col-md-12">
     <div class="record-toolbar d-flex align-items-center">
-      <div class="ml-auto btn-light btn-group">
+      <div class="ms-auto btn-light btn-group">
         <%= link_to I18n.t('enumeration._frontend.action.download_csv'), {:controller => 'enumerations', :action => 'csv'}, :class => 'btn btn-sm' %>
       </div>
       <div class="clearfix"></div>

--- a/frontend/app/views/enumerations/index.html.erb
+++ b/frontend/app/views/enumerations/index.html.erb
@@ -17,7 +17,7 @@
       <div>
         <fieldset>
           <div class="form-group row required">
-            <label class="col-form-label col-md-3 text-right" for="enum_selector"><%= I18n.t("enumeration._frontend.messages.name_selector") %></label>
+            <label class="col-form-label col-md-3 text-end" for="enum_selector"><%= I18n.t("enumeration._frontend.messages.name_selector") %></label>
             <div class="controls">
               <%
                 enum_options = @enumerations.map {|e|

--- a/frontend/app/views/events/_form.html.erb
+++ b/frontend/app/views/events/_form.html.erb
@@ -57,7 +57,7 @@
     <h3><%= I18n.t("linked_agent._plural") %></h3>
 
     <div class="form-group row">
-      <div class="control-label col-sm-2 text-right"><%= I18n.t("linked_agent._plural") %></div>
+      <div class="control-label col-sm-2 text-end"><%= I18n.t("linked_agent._plural") %></div>
       <div class="controls token-list col-sm-4">
         <% form['linked_agents'].each do |linked_agent| %>
           <%= render_token :object => linked_agent['_resolved'],
@@ -79,7 +79,7 @@
     <h3><%= I18n.t("linked_record._plural") %></h3>
 
     <div class="form-group row">
-      <div class="control-label col-sm-2 text-right"><%= I18n.t("linked_record._plural") %></div>
+      <div class="control-label col-sm-2 text-end"><%= I18n.t("linked_record._plural") %></div>
       <div class="controls token-list col-sm-4">
         <% form['linked_records'].each do |linked_record| %>
           <%= render_token :object => linked_record['_resolved'],

--- a/frontend/app/views/events/_record_linker.html.erb
+++ b/frontend/app/views/events/_record_linker.html.erb
@@ -51,7 +51,7 @@
       <% end %>
 
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("linked_record.linker_ref.link_title") %>"><span class="caret"></span></a>
+        <a class="btn btn-default dropdown-toggle last" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("linked_record.linker_ref.link_title") %>"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
         </ul>

--- a/frontend/app/views/events/_record_linker.html.erb
+++ b/frontend/app/views/events/_record_linker.html.erb
@@ -6,7 +6,7 @@
    end
 %>
 <div class="form-group required row">
-  <label class="control-label col-sm-2 text-right"
+  <label class="control-label col-sm-2 text-end"
          id="<%= form.id_for("ref") %>_label"
          for="<%= form.id_for("ref") %>">
     <%= I18n.t("linked_record.ref") %>

--- a/frontend/app/views/events/_toolbar.html.erb
+++ b/frontend/app/views/events/_toolbar.html.erb
@@ -8,7 +8,7 @@
       <% end %>
     <% end %>
 
-    <div class="btn-toolbar ml-auto">
+    <div class="btn-toolbar ms-auto">
       <div class="btn-group">
         <div class="btn btn-inline-form">
           <%= button_delete_action url_for(:controller => :events, :action => :delete, :id => @event.id), { :"data-title" => I18n.t("actions.delete_confirm_title", :title => record_title) } %>

--- a/frontend/app/views/events/index.html.erb
+++ b/frontend/app/views/events/index.html.erb
@@ -9,7 +9,7 @@
   <div class="col-md-9">
     <% if user_can?('update_event_record') %>
       <div class="record-toolbar d-flex align-items-center">
-        <div class="btn-group ml-auto bg-white border">
+        <div class="btn-group ms-auto bg-white border">
           <% if user_can?('manage_repository') %>
               <%= link_to I18n.t("actions.edit_default_values"), {:controller => :events, :action => :defaults}, :class => "btn btn-sm" %>
           <% end %>

--- a/frontend/app/views/groups/_form.html.erb
+++ b/frontend/app/views/groups/_form.html.erb
@@ -5,7 +5,7 @@
     <div class="member-toolbar col-xs-10">
       <div class="form-group">
         <div class="input-group col-xs-6">
-          <label for="new-member" class="sr-only"><%= I18n.t("user.username") %> </label>
+          <label for="new-member" class="visually-hidden"><%= I18n.t("user.username") %> </label>
           <input id="new-member" class="form-control" type="text" autocomplete="off" placeholder="<%= I18n.t("user.username") %>" />
           <span class="input-group-btn">
             <button id="add-new-member" class="btn btn-default"><%= I18n.t("actions.add") %></button>

--- a/frontend/app/views/groups/_toolbar.html.erb
+++ b/frontend/app/views/groups/_toolbar.html.erb
@@ -6,7 +6,7 @@
             <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
           </div>
         </div>
-      <div class="btn-toolbar bg-white border rounded ml-auto">
+      <div class="btn-toolbar bg-white border rounded ms-auto">
         <div class="btn-group">
           <div class="btn btn-inline-form">
             <%= button_delete_action url_for(:controller => :groups, :action => :delete, :id => @group.id), { :"data-title" => I18n.t("actions.delete_confirm_title", :title => @group.description) } %>

--- a/frontend/app/views/groups/index.html.erb
+++ b/frontend/app/views/groups/index.html.erb
@@ -6,7 +6,7 @@
 
   <div class="col-md-9">
     <div class="record-toolbar d-flex align-items-center">
-      <div class="btn-group ml-auto bg-white border">
+      <div class="btn-group ms-auto bg-white border">
         <%= link_to I18n.t("group._frontend.action.create"), {:controller => :groups, :action => :new}, :class => "btn btn-sm btn-default" %>
       </div>
       <br style="clear:both" /> <!-- So dirty! -->

--- a/frontend/app/views/groups/index.html.erb
+++ b/frontend/app/views/groups/index.html.erb
@@ -21,7 +21,7 @@
        <thead>
          <tr>
            <th><%= I18n.t('group.group_code') %></th>
-           <th><span class="sr-only"><%= I18n.t('search_results.actions') %></span></th>
+           <th><span class="visually-hidden"><%= I18n.t('search_results.actions') %></span></th>
          </tr>
        </thead>
        <tbody>

--- a/frontend/app/views/jobs/_form.html.erb
+++ b/frontend/app/views/jobs/_form.html.erb
@@ -157,7 +157,7 @@
             <%= I18n.t("reports.#{code}.title") %>
           </button>
 
-          <button class="ml-auto btn btn-primary select-report mt-0" for="<%= code %>" type="button">
+          <button class="ms-auto btn btn-primary select-report mt-0" for="<%= code %>" type="button">
             <%= I18n.t("reports.translation_defaults.select") %>
           </button>
           <div class="btn-group unselect-report-group">

--- a/frontend/app/views/jobs/_toolbar.html.erb
+++ b/frontend/app/views/jobs/_toolbar.html.erb
@@ -1,7 +1,7 @@
 <% if user_can?('cancel_job') && ["queued", "running"].include?(@job.status) && "true" == AppConfig[:jobs_cancelable].to_s %>
   <% if job_types[@job.job_type] && job_types[@job.job_type]['cancel_permissions'].reject{|perm| user_can?(perm)}.empty? %>
     <div class="record-toolbar d-flex align-items-center">
-      <div class="btn-group btn-toolbar ml-auto bg-white">
+      <div class="btn-group btn-toolbar ms-auto bg-white">
         <div class="btn btn-inline-form">
           <%= button_confirm_action I18n.t("job._frontend.actions.cancel"), url_for(:controller => :jobs, :action => :cancel, :id => @job.id), {
             :class => "btn btn-sm btn-danger"

--- a/frontend/app/views/jobs/index.html.erb
+++ b/frontend/app/views/jobs/index.html.erb
@@ -14,7 +14,7 @@
             <%= I18n.t("job._frontend.actions.create") %>
             <span class="caret"></span>
           </a>
-          <ul class="dropdown-menu dropdown-menu-right">
+          <ul class="dropdown-menu dropdown-menu-end">
             <% job_types.each do |type, perms| %>
               <% next if type == 'generate_slugs_job' && !AppConfig[:use_human_readable_urls] %>
               <% next if type == 'generate_arks_job' && !AppConfig[:arks_enabled] %>

--- a/frontend/app/views/jobs/index.html.erb
+++ b/frontend/app/views/jobs/index.html.erb
@@ -10,7 +10,7 @@
     <% if user_can?('create_job') %>
       <div class="record-toolbar d-flex align-items-center">
         <div class="btn-group bg-white border rounded">
-          <a class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);">
+          <a class="btn btn-sm btn-default dropdown-toggle" data-bs-toggle="dropdown" href="javascript:void(0);">
             <%= I18n.t("job._frontend.actions.create") %>
             <span class="caret"></span>
           </a>

--- a/frontend/app/views/linked_events/_show.html.erb
+++ b/frontend/app/views/linked_events/_show.html.erb
@@ -11,8 +11,8 @@
             <th><%= I18n.t("event.outcome") %></th>
             <th><%= I18n.t("linked_agent._plural") %></th>
             <th><%= I18n.t("linked_record._plural") %></th>
-            <th><span class="sr-only">Audit information</span></th>
-            <th><span class="sr-only"><%= I18n.t("search_results.actions") %></span></th>
+            <th><span class="visually-hidden">Audit information</span></th>
+            <th><span class="visually-hidden"><%= I18n.t("search_results.actions") %></span></th>
           </tr>
           <% linked_events.each do |event| %>
             <% record = event['_resolved'] %>

--- a/frontend/app/views/location_profiles/_linker.html.erb
+++ b/frontend/app/views/location_profiles/_linker.html.erb
@@ -43,7 +43,7 @@
              data-exclude='<%= exclude_ids.to_json %>'
       />
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("location_profile.linker.link_title") %>"><span class="caret"></span></a>
+        <a class="btn btn-default dropdown-toggle last border-dark border-start-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("location_profile.linker.link_title") %>"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn dropdown-item"><%= I18n.t("actions.browse") %></a></li>
           <% if allow_create && user_can?('update_location_profile_record') %>

--- a/frontend/app/views/location_profiles/_linker.html.erb
+++ b/frontend/app/views/location_profiles/_linker.html.erb
@@ -43,7 +43,7 @@
              data-exclude='<%= exclude_ids.to_json %>'
       />
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center" data-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("location_profile.linker.link_title") %>"><span class="caret"></span></a>
+        <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("location_profile.linker.link_title") %>"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn dropdown-item"><%= I18n.t("actions.browse") %></a></li>
           <% if allow_create && user_can?('update_location_profile_record') %>

--- a/frontend/app/views/location_profiles/_toolbar.html.erb
+++ b/frontend/app/views/location_profiles/_toolbar.html.erb
@@ -6,7 +6,7 @@
       </div>
     <% end %>
     <% if !['new', 'create'].include?(controller.action_name) %>
-      <div class="btn-toolbar bg-white rounded border ml-auto">
+      <div class="btn-toolbar bg-white rounded border ms-auto">
         <div class="btn-group">
           <div class="btn btn-inline-form">
             <%= button_delete_action url_for(:controller => :location_profiles, :action => :delete, :id => @location_profile.id), { :"data-title" => I18n.t("actions.delete_confirm_title", :title => @location_profile.name) } unless @location_profile.id.nil? %>

--- a/frontend/app/views/location_profiles/index.html.erb
+++ b/frontend/app/views/location_profiles/index.html.erb
@@ -8,7 +8,7 @@
   </div>
   <div class="col-md-9">
     <div class="record-toolbar d-flex align-items-center">
-      <div class="btn-group ml-auto bg-white border rounded">
+      <div class="btn-group ms-auto bg-white border rounded">
         <%= link_to I18n.t("location_profile._frontend.action.create"), {:controller => :location_profiles, :action => :new}, :class => "btn btn-sm btn-light" %>
       </div>
       <br style="clear:both" />

--- a/frontend/app/views/locations/_batch_form.html.erb
+++ b/frontend/app/views/locations/_batch_form.html.erb
@@ -1,7 +1,7 @@
 <table class="table table-striped table-bordered table-condensed table-spreadsheet">
   <thead>
   <tr>
-    <th><span class="sr-only"><%= I18n.t("search_results.selected") %></span></th>
+    <th><span class="visually-hidden"><%= I18n.t("search_results.selected") %></span></th>
     <th class="required"><%= I18n.t("location_batch.label") %></th>
     <th><%= I18n.t("location_batch.prefix") %></th>
     <th class="highlighted required"><%= I18n.t("location_batch.start") %></th>

--- a/frontend/app/views/locations/_linker.html.erb
+++ b/frontend/app/views/locations/_linker.html.erb
@@ -54,7 +54,7 @@
           <% end %>
           
           <div class="input-group-btn">
-            <a class="btn btn-default dropdown-toggle last locations" data-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("location.linker.link_title") %>" aria-label="<%= I18n.t("location.linker.link_title") %>"><span class="caret"></span></a>
+            <a class="btn btn-default dropdown-toggle last locations" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("location.linker.link_title") %>" aria-label="<%= I18n.t("location.linker.link_title") %>"><span class="caret"></span></a>
             <ul class="dropdown-menu">
               <% if enable_space_calculator %>
                 <li><a href="javascript:void(0);" class="show-space-calculator-btn" data-calculator-url="<%= url_for :controller => :space_calculator, :action => :show, :inline => true %>" data-modal-title="<%= I18n.t("space_calculator.modal_title") %>" data-modal-content="<%= I18n.t("space_calculator.modal_loading") %>"><%= I18n.t("location._frontend.action.show_space_calculator") %></a></li>

--- a/frontend/app/views/locations/_toolbar.html.erb
+++ b/frontend/app/views/locations/_toolbar.html.erb
@@ -11,7 +11,7 @@
         <%= I18n.t("actions.toolbar_disabled_message") %>
       </div>
     <% end %>
-    <div class="btn-toolbar ml-auto">
+    <div class="btn-toolbar ms-auto">
       <div class="btn btn-inline-form bg-white border rounded">
         <%= button_delete_action url_for(:controller => :locations, :action => :delete, :id => @location.id), { :"data-title" => I18n.t("actions.delete_confirm_title", :title => @location.title), :"data-message" => I18n.t("location._frontend.action.delete_confirm_message"),} %>
       </div>

--- a/frontend/app/views/locations/index.html.erb
+++ b/frontend/app/views/locations/index.html.erb
@@ -9,7 +9,7 @@
   <div class="col-md-9">
     <% if user_can?('update_location_record') %>
       <div class="record-toolbar d-flex align-items-center">
-        <div class="btn-group ml-auto bg-white border rounded">
+        <div class="btn-group ms-auto bg-white border rounded">
           <% if user_can?('manage_repository') %>
               <%= link_to I18n.t("actions.edit_default_values"), {:controller => :locations, :action => :defaults}, :class => "btn btn-sm" %>
           <% end %>

--- a/frontend/app/views/locations/index.html.erb
+++ b/frontend/app/views/locations/index.html.erb
@@ -14,8 +14,8 @@
               <%= link_to I18n.t("actions.edit_default_values"), {:controller => :locations, :action => :defaults}, :class => "btn btn-sm" %>
           <% end %>
           <%= link_to I18n.t("actions.export_csv"), request.parameters.merge({ :format => :csv, :fields => fields}), id: "searchExport",  class:  "btn btn-sm btn-info" %>
-          <%= link_to I18n.t("location._frontend.action.create"), {:controller => :locations, :action => :new}, :class => "btn btn-sm border-right" %>
-          <%= link_to I18n.t("location._frontend.action.batch"), {:controller => :locations, :action => :batch}, :class => "btn btn-sm border-right" %>
+          <%= link_to I18n.t("location._frontend.action.create"), {:controller => :locations, :action => :new}, :class => "btn btn-sm border-end" %>
+          <%= link_to I18n.t("location._frontend.action.batch"), {:controller => :locations, :action => :batch}, :class => "btn btn-sm border-end" %>
           <%= button_edit_multiple_action(:locations) %>
           <% if user_can?("administer_system") %>
              <%= button_delete_multiple_action(:locations) %>

--- a/frontend/app/views/notes/_form.html.erb
+++ b/frontend/app/views/notes/_form.html.erb
@@ -21,9 +21,9 @@
     <%= link_to_help :topic => "#{form['jsonmodel_type']}_notes" %>
 
     <% if show_apply_note_order_action %>
-      <button class="btn btn-sm btn-default float-right border bg-white mx-1 mt-1 apply-note-order" disabled="disabled"><%= I18n.t("note._frontend.action.apply_note_order") %></button>
+      <button class="btn btn-sm btn-default float-end border bg-white mx-1 mt-1 apply-note-order" disabled="disabled"><%= I18n.t("note._frontend.action.apply_note_order") %></button>
     <% end %>
-    <button class="btn btn-sm btn-default float-right border bg-white mx-1 mt-1 add-note"><%= I18n.t(add_button_text) %></button>
+    <button class="btn btn-sm btn-default float-end border bg-white mx-1 mt-1 add-note"><%= I18n.t(add_button_text) %></button>
 
   </<%= header_size%>>
   <div class="subrecord-form-container mixed-content-anchor">

--- a/frontend/app/views/notes/_form_required.html.erb
+++ b/frontend/app/views/notes/_form_required.html.erb
@@ -19,9 +19,9 @@
     <%= link_to_help :topic => "#{form['jsonmodel_type']}_notes" %>
 
     <% if show_apply_note_order_action %>
-      <button class="btn btn-sm btn-default float-right border bg-white mx-1 mt-1 apply-note-order" disabled="disabled"><%= I18n.t("note._frontend.action.apply_note_order") %></button>
+      <button class="btn btn-sm btn-default float-end border bg-white mx-1 mt-1 apply-note-order" disabled="disabled"><%= I18n.t("note._frontend.action.apply_note_order") %></button>
     <% end %>
-    <button class="btn btn-sm btn-default border bg-white mx-1 mt-1 float-right add-note"><%= I18n.t("note._frontend.action.add") %></button>
+    <button class="btn btn-sm btn-default border bg-white mx-1 mt-1 float-end add-note"><%= I18n.t("note._frontend.action.add") %></button>
 
   </<%= header_size%>>
   <div class="subrecord-form-container mixed-content-anchor">

--- a/frontend/app/views/notes/_template.html.erb
+++ b/frontend/app/views/notes/_template.html.erb
@@ -118,7 +118,7 @@
       </ul>
     </div>
   <% else %>
-    <label class="sr-only" for="<%= form.id_for(nil) %>"><%= I18n.t("content_items.content") %></label>
+    <label class="visually-hidden" for="<%= form.id_for(nil) %>"><%= I18n.t("content_items.content") %></label>
     <%= form.textarea(nil, item, :class => "mixed-content") %>
   <% end %>
   </div>

--- a/frontend/app/views/oai_config/edit.html.erb
+++ b/frontend/app/views/oai_config/edit.html.erb
@@ -84,7 +84,7 @@
           <table class="table table-striped table-bordered table-sm">
             <thead>
               <th>Name</th>
-              <th><span class="sr-only"><%= I18n.t('search_results.actions') %></span></th>
+              <th><span class="visually-hidden"><%= I18n.t('search_results.actions') %></span></th>
             </thead>
             <tbody>
               <% @repositories.each do |r| %>

--- a/frontend/app/views/preferences/_toolbar.html.erb
+++ b/frontend/app/views/preferences/_toolbar.html.erb
@@ -5,7 +5,7 @@
     </div>
   </div>
 
-  <div class="btn-toolbar ml-auto bg-white border rounded">
+  <div class="btn-toolbar ms-auto bg-white border rounded">
     <div class="btn-group">
       <div class="btn btn-inline-form">
         <%= button_confirm_action I18n.t("actions.reset"),

--- a/frontend/app/views/related_agents/_form.html.erb
+++ b/frontend/app/views/related_agents/_form.html.erb
@@ -9,7 +9,7 @@
   <h3 class="subrecord-form-heading">
     <%= wrap_with_tooltip(I18n.t("related_agent._plural"), "agent.related_agent_tooltip", "subrecord-form-heading-label") %>
     <%= link_to_help :topic => "agent_related_agents" %>
-    <button class="btn btn-sm btn-default add-related-agent-for-type-btn float-right border bg-white mx-1 mt-1"><%= I18n.t("actions.add") %> <%= I18n.t("related_agent._singular") %></button>
+    <button class="btn btn-sm btn-default add-related-agent-for-type-btn float-end border bg-white mx-1 mt-1"><%= I18n.t("actions.add") %> <%= I18n.t("related_agent._singular") %></button>
   </h3>
 
   <div id="related-agents-container" class="subrecord-form-container">

--- a/frontend/app/views/related_agents/_form_required.html.erb
+++ b/frontend/app/views/related_agents/_form_required.html.erb
@@ -7,7 +7,7 @@
   <h3 class="subrecord-form-heading">
     <%= I18n.t("related_agent._plural") %>
     <%= link_to_help :topic => "#{@agent_type}_related_agents" %>
-    <button class="btn btn-sm btn-default add-related-agent-for-type-btn float-right border bg-white mx-1 mt-1"><%= I18n.t("actions.add") %> <%= I18n.t("related_agent._singular") %></button>
+    <button class="btn btn-sm btn-default add-related-agent-for-type-btn float-end border bg-white mx-1 mt-1"><%= I18n.t("actions.add") %> <%= I18n.t("related_agent._singular") %></button>
   </h3>
 
   <div id="related-agents-container" class="subrecord-form-container">

--- a/frontend/app/views/repositories/_linker.html.erb
+++ b/frontend/app/views/repositories/_linker.html.erb
@@ -44,7 +44,7 @@
              data-exclude='<%= exclude_ids.to_json %>'
       />
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center" data-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("repository.linker.link_title") %>"><span class="caret"></span></a>
+        <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("repository.linker.link_title") %>"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn dropdown-item"><%= I18n.t("actions.browse") %></a></li>
         </ul>

--- a/frontend/app/views/repositories/_linker.html.erb
+++ b/frontend/app/views/repositories/_linker.html.erb
@@ -44,7 +44,7 @@
              data-exclude='<%= exclude_ids.to_json %>'
       />
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("repository.linker.link_title") %>"><span class="caret"></span></a>
+        <a class="btn btn-default dropdown-toggle last border-dark border-start-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("repository.linker.link_title") %>"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn dropdown-item"><%= I18n.t("actions.browse") %></a></li>
         </ul>

--- a/frontend/app/views/repositories/_toolbar.html.erb
+++ b/frontend/app/views/repositories/_toolbar.html.erb
@@ -6,7 +6,7 @@
           <%= link_to I18n.t("actions.edit"), {:controller => :repositories, :action => :edit, :id => @repository.id}, :class => "btn btn-sm btn-primary" %>
         </div>
       <% end %>
-      <div class="ml-auto">
+      <div class="ms-auto">
         <% if session[:repo_id] != @repository.id and @repositories.any?{|r| r['uri'] === @repository.uri} %>
           <%= form_for @repository, :as => "repository", :url => {:action => :select}, :html => {:style => "display: inline;"} do |f| %>
             <button type="submit" class="btn btn-sm btn-success"><%= I18n.t("repository._frontend.action.select") %></button>

--- a/frontend/app/views/repositories/index.html.erb
+++ b/frontend/app/views/repositories/index.html.erb
@@ -9,7 +9,7 @@
   <div class="col-md-9">
     <% if user_can?('manage_repository') %>
       <div class="record-toolbar">
-        <div class="btn-group float-right">
+        <div class="btn-group float-end">
           <%= link_to I18n.t("repository._frontend.action.create"), {:controller => :repositories, :action => :new}, :class => "btn btn-sm btn-light btn-default" %>
         </div>
         <br style="clear:both" /> <!-- So dirty! -->

--- a/frontend/app/views/repositories/transfer.html.erb
+++ b/frontend/app/views/repositories/transfer.html.erb
@@ -57,7 +57,7 @@
             %>
             </div>
 
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default pull-right ml-auto border bg-white" %>
+            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default pull-right ms-auto border bg-white" %>
           </div>
         <% end %>
       </section>

--- a/frontend/app/views/resources/_linker.html.erb
+++ b/frontend/app/views/resources/_linker.html.erb
@@ -57,7 +57,7 @@
 
          <% end %>
          <div class="input-group-btn">
-           <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("#{record_types}.linker.link_title") %>" aria-expanded="false" aria-label="<%= I18n.t("#{record_types}.linker.link_title") %>"></a>
+           <a class="btn btn-default dropdown-toggle last border-dark border-start-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("#{record_types}.linker.link_title") %>" aria-expanded="false" aria-label="<%= I18n.t("#{record_types}.linker.link_title") %>"></a>
            <ul class="dropdown-menu">
              <li class='dropdown-item'><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
            </ul>

--- a/frontend/app/views/resources/_linker.html.erb
+++ b/frontend/app/views/resources/_linker.html.erb
@@ -57,7 +57,7 @@
 
          <% end %>
          <div class="input-group-btn">
-           <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center" data-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("#{record_types}.linker.link_title") %>" aria-expanded="false" aria-label="<%= I18n.t("#{record_types}.linker.link_title") %>"></a>
+           <a class="btn btn-default dropdown-toggle last border-dark border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("#{record_types}.linker.link_title") %>" aria-expanded="false" aria-label="<%= I18n.t("#{record_types}.linker.link_title") %>"></a>
            <ul class="dropdown-menu">
              <li class='dropdown-item'><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
            </ul>

--- a/frontend/app/views/resources/_linker.html.erb
+++ b/frontend/app/views/resources/_linker.html.erb
@@ -13,7 +13,7 @@
 
 %>
 <div class="form-group row required">
-   <label class="control-label text-right <%= layout != 'stacked' ? 'col-sm-2' : '' %>"
+   <label class="control-label text-end <%= layout != 'stacked' ? 'col-sm-2' : '' %>"
           id="<%= form.id_for("ref") %>_label"
           for="<%= form.id_for("ref") %>_combobox">
      <%= field_label %>

--- a/frontend/app/views/resources/_toolbar.html.erb
+++ b/frontend/app/views/resources/_toolbar.html.erb
@@ -8,7 +8,7 @@
         :action => :download_ead, :id => @resource.id, :include_unpublished => "${include_unpublished}",
         :include_daos => "${include_daos}", :numbered_cs => "${numbered_cs}", :print_pdf => "${print_pdf}",
         :ead3 => "${ead3}" )%>">
-        <a href="#" data-toggle="dropdown" class="menu-with-options download-ead-action" title="<%= I18n.t("actions.export_ead") %>"><%= I18n.t("actions.export_ead") %></a>
+        <a href="#" data-bs-toggle="dropdown" class="menu-with-options download-ead-action" title="<%= I18n.t("actions.export_ead") %>"><%= I18n.t("actions.export_ead") %></a>
         <div class="dropdown-menu" id="form_download_ead">
           <fieldset>
             <input type="hidden" name="id", value="<%= @resource.id %>" />
@@ -35,7 +35,7 @@
       </li>
 
       <li class="dropdown-submenu" id="download-marc-dropdown" data-download-marc-url="<%= url_for(:controller => :exports, :action => :download_marc, :id => @resource.id, :include_unpublished_marc => "${include_unpublished_marc}")%>">
-        <a href="#" data-toggle="dropdown" class="menu-with-options download-marc-action" title="<%= I18n.t("actions.export_marc") %>"><%= I18n.t("actions.export_marc") %></a>
+        <a href="#" data-bs-toggle="dropdown" class="menu-with-options download-marc-action" title="<%= I18n.t("actions.export_marc") %>"><%= I18n.t("actions.export_marc") %></a>
         <div class="dropdown-menu" id="form_download_marc">
           <fieldset>
             <input type="hidden" name="id", value="<%= @resource.id %>" />

--- a/frontend/app/views/resources/index.html.erb
+++ b/frontend/app/views/resources/index.html.erb
@@ -13,7 +13,7 @@
          <div class="btn-group ml-auto bg-white border">
           <% if user_can?('manage_repository') %>
             <div class="btn-group">
-              <a class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);">
+              <a class="btn btn-sm btn-default dropdown-toggle" data-bs-toggle="dropdown" href="javascript:void(0);">
                 <%= I18n.t("actions.edit_default_values") %>
               </a>
               <ul class="dropdown-menu dropdown-menu-right">

--- a/frontend/app/views/resources/index.html.erb
+++ b/frontend/app/views/resources/index.html.erb
@@ -16,7 +16,7 @@
               <a class="btn btn-sm btn-default dropdown-toggle" data-bs-toggle="dropdown" href="javascript:void(0);">
                 <%= I18n.t("actions.edit_default_values") %>
               </a>
-              <ul class="dropdown-menu dropdown-menu-right">
+              <ul class="dropdown-menu dropdown-menu-end">
                 <li class='dropdown-item'><%= link_to I18n.t("resource._singular"), {:controller => :resources, :action => :defaults} %></li>
                 <li class='dropdown-item'> <%= link_to I18n.t("resource_component._singular"), {:controller => :archival_objects, :action => :defaults} %></li>
               </ul>

--- a/frontend/app/views/resources/index.html.erb
+++ b/frontend/app/views/resources/index.html.erb
@@ -10,7 +10,7 @@
    <div class="col-md-9">
      <% if user_can?('update_resource_record') %>
        <div class="record-toolbar d-flex align-items-center">
-         <div class="btn-group ml-auto bg-white border">
+         <div class="btn-group ms-auto bg-white border">
           <% if user_can?('manage_repository') %>
             <div class="btn-group">
               <a class="btn btn-sm btn-default dropdown-toggle" data-bs-toggle="dropdown" href="javascript:void(0);">

--- a/frontend/app/views/search/_components_switch.html.erb
+++ b/frontend/app/views/search/_components_switch.html.erb
@@ -1,6 +1,6 @@
 <p id="component_switch">
   <label>
-    <span class="sr-only">Show components?</span>
+    <span class="visually-hidden">Show components?</span>
     <%= check_box_tag "component_switch_checkbox", params[:include_components], params[:include_components] === "true", :onclick => "location.href = $('#component_switch_link').attr('href');" %>
   </label>
   <%= link_to I18n.t("search_results.component_switch"), build_search_params({"include_components" => !(params[:include_components]==="true")}), :id => "component_switch_link" %>

--- a/frontend/app/views/search/_embedded.html.erb
+++ b/frontend/app/views/search/_embedded.html.erb
@@ -9,7 +9,7 @@
 <section id="<%= section_id %>" class="subrecord-form-dummy">
   <h3 class="subrecord-form-heading d-flex align-items-center">
     <%= heading_text %>
-    <%= link_to I18n.t("actions.view_search_results"), html_search_url, :class => "btn btn-sm bg-white border ml-auto" %>
+    <%= link_to I18n.t("actions.view_search_results"), html_search_url, :class => "btn btn-sm bg-white border ms-auto" %>
   </h3>
   <div class="subrecord-form-container">
     <div class="subrecord-form-fields embedded-search" data-url="<%= ajax_search_url %>">

--- a/frontend/app/views/search/_filter.html.erb
+++ b/frontend/app/views/search/_filter.html.erb
@@ -3,7 +3,7 @@
   <div class="well">
     <h3 class="d-flex">
       <%= I18n.t "search_results.filtered_by" %>
-      <%= link_to I18n.t("search_results.clear_all"), build_search_params({"q" => "", "filter_term" => []}), :class => "btn btn-xs pull-right bg-white border ml-auto" %>
+      <%= link_to I18n.t("search_results.clear_all"), build_search_params({"q" => "", "filter_term" => []}), :class => "btn btn-xs pull-right bg-white border ms-auto" %>
     </h3>
     <ul>
       <% if @search_data.query? %>

--- a/frontend/app/views/search/_filter.html.erb
+++ b/frontend/app/views/search/_filter.html.erb
@@ -38,7 +38,7 @@
       <% end %>
     <% end %>
     <div class="input-group w-100">
-      <label for="filter-text" class="sr-only">Filter by text</label>
+      <label for="filter-text" class="visually-hidden">Filter by text</label>
       <input class="text-filter-field form-control" type="text" placeholder="<%= I18n.t("search_results.text_placeholder") %>" name="q" value="<%= params[:q] %>" id="filter-text"/>
       <div class="input-group-btn">
         <button class="btn btn-default" title="<%= I18n.t("search_results.text_placeholder") %>" aria-label="<%= I18n.t("search_results.text_placeholder") %>"><span class="glyphicon glyphicon-search"></span></button>

--- a/frontend/app/views/search/_results.html.erb
+++ b/frontend/app/views/search/_results.html.erb
@@ -9,7 +9,7 @@
   <div class="col-md-9">
     <div class="record-toolbar  d-flex align-items-center">
       <% unless @hide_csv_download %>
-        <div class="btn-group ml-auto">
+        <div class="btn-group ms-auto">
           <%= link_to I18n.t("actions.export_csv"), request.parameters.merge({ :format => :csv, :fields => fields}), id: "searchExport",  class:  "btn btn-sm btn-info" %>
         </div>
       <% end %>

--- a/frontend/app/views/shared/_advanced_search.html.erb
+++ b/frontend/app/views/shared/_advanced_search.html.erb
@@ -183,7 +183,7 @@
           <option value="empty" {if query.empty}selected{/if}><%= I18n.t("advanced_search.text_operator.empty") %></option>
         </select>
       </div>
-      <div class="input-group-addon search-value ml-4">
+      <div class="input-group-addon search-value ms-4">
         <label for="v${index}"><%= I18n.t "advanced_search.search_text" %></label>
         <%= text_field_tag "v${index}", "${query.value}", :id => "v${index}", :class => 'form-control', :onkeydown => "return processKey(event)" %>
       </div>
@@ -210,7 +210,7 @@
           <% end %>
         </select>
       </div>
-      <div class="input-group-addon search-value ml-4">
+      <div class="input-group-addon search-value ms-4">
         <label for="v${index}"><%= I18n.t "advanced_search.search_date" %></label>
                                                     <%= text_field_tag "v${index}", "${query.value}", :id => "v${index}", :class => "date-field form-control", :"data-format" => "yyyy-mm-dd", :"data-date" => Date.today.strftime('%Y-%m-%d'), :"data-label" => I18n.t("actions.date_picker_toggle"), :"data-force-parse" => false %>
       </div>

--- a/frontend/app/views/shared/_advanced_search.html.erb
+++ b/frontend/app/views/shared/_advanced_search.html.erb
@@ -264,7 +264,7 @@
     </div>
     <div class="col-md-1">
       <div>
-        <button class="btn btn-success advanced-search-add-row-dropdown" data-toggle="dropdown" title="<%= I18n.t("advanced_search.add_row") %>" aria-label="<%= I18n.t("advanced_search.add_row") %>">
+        <button class="btn btn-success advanced-search-add-row-dropdown" data-bs-toggle="dropdown" title="<%= I18n.t("advanced_search.add_row") %>" aria-label="<%= I18n.t("advanced_search.add_row") %>">
           <span class="glyphicon glyphicon-plus glyphicon-white"></span>
           <span class="caret"></span>
         </button>

--- a/frontend/app/views/shared/_component_toolbar.html.erb
+++ b/frontend/app/views/shared/_component_toolbar.html.erb
@@ -24,7 +24,7 @@
           </div>
         <% end %>
       <% end %>
-      <div class="btn-toolbar ml-auto">
+      <div class="btn-toolbar ms-auto">
         <div class="btn-group">
           <% if user_can?('update_event_record') && supports_events && ((suppressible && !record.suppressed) || !suppressible ) %>
             <%= render_aspace_partial :partial => "shared/event_dropdown", :locals => {:record => record} %>

--- a/frontend/app/views/shared/_component_toolbar.html.erb
+++ b/frontend/app/views/shared/_component_toolbar.html.erb
@@ -60,7 +60,7 @@
           <% end %>
 
           <div class="btn-group dropdown" id="other-dropdown" style="display: none">
-            <a class="btn btn-sm  dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+            <a class="btn btn-sm  dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
               <%= I18n.t('actions.more') %>
               <span class="caret"></span>
             </a>

--- a/frontend/app/views/shared/_event_dropdown.html.erb
+++ b/frontend/app/views/shared/_event_dropdown.html.erb
@@ -16,7 +16,7 @@
           </fieldset>
           <div class="form-actions">
             <button class="btn add-event-button border"><%= I18n.t("actions.add_event") %></button>
-            <a class="btn btn-close ml-auto btn-danger" href="#"><%= I18n.t("actions.cancel") %></a>
+            <a class="btn btn-close ms-auto btn-danger" href="#"><%= I18n.t("actions.cancel") %></a>
           </div>
         <% end %>
       </li>

--- a/frontend/app/views/shared/_event_dropdown.html.erb
+++ b/frontend/app/views/shared/_event_dropdown.html.erb
@@ -10,7 +10,7 @@
       <li class=dropdown-item'>
         <%= form_context :add_event, {} do |form| %>
           <fieldset>
-            <legend class="sr-only">Add event:</legend>
+            <legend class="visually-hidden">Add event:</legend>
             <label for="add_event_event_type"><%=  I18n.t("actions.add_event_event_type") %></label>
             <%= select_tag "add_event_event_type", options_for_select(event_types.map{|event_type| [I18n.t("enumerations.event_event_type.#{event_type}", :default => event_type), event_type]}), :'aria-labelledby' => "form_add_event"%>
           </fieldset>

--- a/frontend/app/views/shared/_event_dropdown.html.erb
+++ b/frontend/app/views/shared/_event_dropdown.html.erb
@@ -3,7 +3,7 @@
 %>
 
   <div id="add-event-dropdown" class="btn-group dropdown" data-no-change-tracking="true" data-add-event-url="<%= add_new_event_url(record)  %>">
-    <button class="btn btn-sm btn-default dropdown-toggle add-event-action" data-toggle="dropdown" role="button" aria-expanded="false" title="<%= I18n.t("actions.add_event") %>">
+    <button class="btn btn-sm btn-default dropdown-toggle add-event-action" data-bs-toggle="dropdown" role="button" aria-expanded="false" title="<%= I18n.t("actions.add_event") %>">
       <%= I18n.t("actions.add_event") %> <span class="caret"></span>
     </button>
     <ul class="dropdown-menu add-event-form dropdown-menu-right">

--- a/frontend/app/views/shared/_event_dropdown.html.erb
+++ b/frontend/app/views/shared/_event_dropdown.html.erb
@@ -6,7 +6,7 @@
     <button class="btn btn-sm btn-default dropdown-toggle add-event-action" data-bs-toggle="dropdown" role="button" aria-expanded="false" title="<%= I18n.t("actions.add_event") %>">
       <%= I18n.t("actions.add_event") %> <span class="caret"></span>
     </button>
-    <ul class="dropdown-menu add-event-form dropdown-menu-right">
+    <ul class="dropdown-menu add-event-form dropdown-menu-end">
       <li class=dropdown-item'>
         <%= form_context :add_event, {} do |form| %>
           <fieldset>

--- a/frontend/app/views/shared/_header_global.html.erb
+++ b/frontend/app/views/shared/_header_global.html.erb
@@ -1,5 +1,5 @@
 <div class="global-header">
-  <span class="sr-only">
+  <span class="visually-hidden">
     <h1>
       <%= I18n.t("header.staff_interface") %>
     </h1>

--- a/frontend/app/views/shared/_header_repository.html.erb
+++ b/frontend/app/views/shared/_header_repository.html.erb
@@ -10,7 +10,7 @@
             <%= link_to raw('<span class="glyphicon glyphicon-home"></span><span class="sr-only">' + I18n.t("breadcrumb.home") + '</span>'), :controller => :welcome, :action => :index %>
           </li>
           <li class="dropdown browse-container px-4">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= I18n.t("actions.browse") %> <b class="caret"></b></a>
+            <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown"><%= I18n.t("actions.browse") %> <b class="caret"></b></a>
             <ul class="dropdown-menu">
               <li class='dropdown-item'><%= link_to I18n.t("accession._plural"), :controller => :accessions, :action => :index %></li>
               <li class='dropdown-item'><%= link_to I18n.t("resource._plural"), :controller => :resources, :action => :index %></li>
@@ -32,7 +32,7 @@
                   'update_subject_record', 'update_event_record',
                   'update_agent_record', 'update_location_record', 'update_container_profile'].find {|p| user_can?(p)} %>
             <li class="dropdown create-container px-4">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= I18n.t("navbar.create") %> <b class="caret"></b></a>
+              <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown"><%= I18n.t("navbar.create") %> <b class="caret"></b></a>
               <ul class="dropdown-menu">
                 <% if ['update_accession_record', 'update_resource_record', 'update_digital_object_record'].find {|p| user_can?(p)} %>
                   <% if user_can?('update_accession_record') %>
@@ -130,7 +130,7 @@
             <li class="repo-container">
               <div class="btn-group bg-white border rounded align-items-center">
                 <a href="<%= url_for :controller => :repositories, :action => :show, :id => session[:repo_id] %>" class="btn btn-default navbar-btn">
-                  <span class="repository-label has-popover" tabindex="0" data-trigger="focus hover" data-placement="bottom" data-html='true' data-toggle='popover' data-title="<span class='icomoon icon-repository'>&#160;</span><%= CGI::escapeHTML(current_repo['repo_code']) %>" data-content="<%= CGI::escapeHTML(current_repo['name']) %>">
+                  <span class="repository-label has-popover" tabindex="0" data-trigger="focus hover" data-placement="bottom" data-html='true' data-bs-toggle='popover' data-title="<span class='icomoon icon-repository'>&#160;</span><%= CGI::escapeHTML(current_repo['repo_code']) %>" data-content="<%= CGI::escapeHTML(current_repo['name']) %>">
                     <span class="icomoon icon-repository"></span><span class="current-repository-id"><% if current_repo %><%= current_repo['repo_code'] %><% end %></span>
                     <% unless current_repo.publish %>
                       <span class="label label-warning"><%= I18n.t("navbar.unpublished") %></span>
@@ -138,7 +138,7 @@
                   </span>
                 </a>
                 <div class="btn-group border-left">
-                  <a class="btn btn-default navbar-btn dropdown-toggle last" data-toggle="dropdown" href="#" title="<%= I18n.t("navbar.repository_settings") %>" aria-label="<%= I18n.t("navbar.repository_settings") %>"><span class="glyphicon glyphicon-cog"></span> <span class="caret"></span></a>
+                  <a class="btn btn-default navbar-btn dropdown-toggle last" data-bs-toggle="dropdown" href="#" title="<%= I18n.t("navbar.repository_settings") %>" aria-label="<%= I18n.t("navbar.repository_settings") %>"><span class="glyphicon glyphicon-cog"></span> <span class="caret"></span></a>
                   <ul class="dropdown-menu dropdown-menu-right">
                     <% found_an_item = false %>
                     <% if user_can?('manage_repository') %>

--- a/frontend/app/views/shared/_header_repository.html.erb
+++ b/frontend/app/views/shared/_header_repository.html.erb
@@ -7,7 +7,7 @@
       <% if session[:user] and session[:repo_id] %>
         <ul class="nav navbar-nav">
           <li class="px-4"<% if controller_name === "welcome" %>class="active px-4"<% end %>>
-            <%= link_to raw('<span class="glyphicon glyphicon-home"></span><span class="sr-only">' + I18n.t("breadcrumb.home") + '</span>'), :controller => :welcome, :action => :index %>
+            <%= link_to raw('<span class="glyphicon glyphicon-home"></span><span class="visually-hidden">' + I18n.t("breadcrumb.home") + '</span>'), :controller => :welcome, :action => :index %>
           </li>
           <li class="dropdown browse-container px-4">
             <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown"><%= I18n.t("actions.browse") %> <b class="caret"></b></a>
@@ -111,7 +111,7 @@
           <li class="px-4">
             <%= form_tag(url_for(:controller => :search, :action => :do_search), :method => :get, :class => "navbar-form pull-left") do %>
               <div class="input-group bg-white border rounded">
-                <label for="global-search-box" class="sr-only sr-only-focusable"><%= I18n.t("navbar.search_placeholder") %></label>
+                <label for="global-search-box" class="visually-hidden visually-hidden-focusable"><%= I18n.t("navbar.search_placeholder") %></label>
                 <input id="global-search-box" type="text" class="form-control border-start-0 border-top-0 border-bottom-0" placeholder="<%= I18n.t("navbar.search_placeholder") %>" name="q" value="<%= params[:q] %>"/>
                 <div class="input-group-append">
                   <button id="global-search-button" class="btn btn-default" title="<%= I18n.t("navbar.search_button_title") %>" aria-label="<%= I18n.t("navbar.search_button_title") %>"><span class="glyphicon glyphicon-search"></span></button>

--- a/frontend/app/views/shared/_header_repository.html.erb
+++ b/frontend/app/views/shared/_header_repository.html.erb
@@ -112,10 +112,10 @@
             <%= form_tag(url_for(:controller => :search, :action => :do_search), :method => :get, :class => "navbar-form pull-left") do %>
               <div class="input-group bg-white border rounded">
                 <label for="global-search-box" class="sr-only sr-only-focusable"><%= I18n.t("navbar.search_placeholder") %></label>
-                <input id="global-search-box" type="text" class="form-control border-left-0 border-top-0 border-bottom-0" placeholder="<%= I18n.t("navbar.search_placeholder") %>" name="q" value="<%= params[:q] %>"/>
+                <input id="global-search-box" type="text" class="form-control border-start-0 border-top-0 border-bottom-0" placeholder="<%= I18n.t("navbar.search_placeholder") %>" name="q" value="<%= params[:q] %>"/>
                 <div class="input-group-append">
                   <button id="global-search-button" class="btn btn-default" title="<%= I18n.t("navbar.search_button_title") %>" aria-label="<%= I18n.t("navbar.search_button_title") %>"><span class="glyphicon glyphicon-search"></span></button>
-                  <button class="btn btn-default search-switcher last border-left" title="<%= I18n.t("navbar.show_advanced_search_button_title") %>" aria-label="<%= I18n.t("navbar.show_advanced_search_button_title") %>" aria-expanded="false" <% if params["advanced"] %>style="display:none"<% end %>><span class='glyphicon glyphicon-chevron-down'></span></button>
+                  <button class="btn btn-default search-switcher last border-start" title="<%= I18n.t("navbar.show_advanced_search_button_title") %>" aria-label="<%= I18n.t("navbar.show_advanced_search_button_title") %>" aria-expanded="false" <% if params["advanced"] %>style="display:none"<% end %>><span class='glyphicon glyphicon-chevron-down'></span></button>
                 </div>
               </div>
             <% end %>
@@ -137,7 +137,7 @@
                     <% end %>
                   </span>
                 </a>
-                <div class="btn-group border-left">
+                <div class="btn-group border-start">
                   <a class="btn btn-default navbar-btn dropdown-toggle last" data-bs-toggle="dropdown" href="#" title="<%= I18n.t("navbar.repository_settings") %>" aria-label="<%= I18n.t("navbar.repository_settings") %>"><span class="glyphicon glyphicon-cog"></span> <span class="caret"></span></a>
                   <ul class="dropdown-menu dropdown-menu-right">
                     <% found_an_item = false %>

--- a/frontend/app/views/shared/_header_repository.html.erb
+++ b/frontend/app/views/shared/_header_repository.html.erb
@@ -126,7 +126,7 @@
             </div>
           </li>
         </ul>
-          <ul class="nav navbar-nav ml-auto">
+          <ul class="nav navbar-nav ms-auto">
             <li class="repo-container">
               <div class="btn-group bg-white border rounded align-items-center">
                 <a href="<%= url_for :controller => :repositories, :action => :show, :id => session[:repo_id] %>" class="btn btn-default navbar-btn">

--- a/frontend/app/views/shared/_header_repository.html.erb
+++ b/frontend/app/views/shared/_header_repository.html.erb
@@ -139,7 +139,7 @@
                 </a>
                 <div class="btn-group border-start">
                   <a class="btn btn-default navbar-btn dropdown-toggle last" data-bs-toggle="dropdown" href="#" title="<%= I18n.t("navbar.repository_settings") %>" aria-label="<%= I18n.t("navbar.repository_settings") %>"><span class="glyphicon glyphicon-cog"></span> <span class="caret"></span></a>
-                  <ul class="dropdown-menu dropdown-menu-right">
+                  <ul class="dropdown-menu dropdown-menu-end">
                     <% found_an_item = false %>
                     <% if user_can?('manage_repository') %>
                       <% found_an_item = true %>

--- a/frontend/app/views/shared/_header_repository.html.erb
+++ b/frontend/app/views/shared/_header_repository.html.erb
@@ -112,11 +112,9 @@
             <%= form_tag(url_for(:controller => :search, :action => :do_search), :method => :get, :class => "navbar-form pull-left") do %>
               <div class="input-group bg-white border rounded">
                 <label for="global-search-box" class="visually-hidden visually-hidden-focusable"><%= I18n.t("navbar.search_placeholder") %></label>
-                <input id="global-search-box" type="text" class="form-control border-start-0 border-top-0 border-bottom-0" placeholder="<%= I18n.t("navbar.search_placeholder") %>" name="q" value="<%= params[:q] %>"/>
-                <div class="input-group-append">
-                  <button id="global-search-button" class="btn btn-default" title="<%= I18n.t("navbar.search_button_title") %>" aria-label="<%= I18n.t("navbar.search_button_title") %>"><span class="glyphicon glyphicon-search"></span></button>
-                  <button class="btn btn-default search-switcher last border-start" title="<%= I18n.t("navbar.show_advanced_search_button_title") %>" aria-label="<%= I18n.t("navbar.show_advanced_search_button_title") %>" aria-expanded="false" <% if params["advanced"] %>style="display:none"<% end %>><span class='glyphicon glyphicon-chevron-down'></span></button>
-                </div>
+                <input id="global-search-box" type="text" class="form-control rounded-start border-top-0 border-bottom-0" placeholder="<%= I18n.t("navbar.search_placeholder") %>" name="q" value="<%= params[:q] %>"/>
+                <button id="global-search-button" class="btn btn-default" title="<%= I18n.t("navbar.search_button_title") %>" aria-label="<%= I18n.t("navbar.search_button_title") %>"><span class="glyphicon glyphicon-search"></span></button>
+                <button class="btn btn-default search-switcher last border-start" title="<%= I18n.t("navbar.show_advanced_search_button_title") %>" aria-label="<%= I18n.t("navbar.show_advanced_search_button_title") %>" aria-expanded="false" <% if params["advanced"] %>style="display:none"<% end %>><span class='glyphicon glyphicon-chevron-down'></span></button>
               </div>
             <% end %>
           </li>

--- a/frontend/app/views/shared/_header_user.html.erb
+++ b/frontend/app/views/shared/_header_user.html.erb
@@ -72,7 +72,7 @@
     <div class="btn-group bg-white align-items-center border rounded">
       <% link_content = "<span class='glyphicon glyphicon-user'></span>&nbsp;<span class='user-label'>#{session[:user]}</span>" %>
       <%= link_to(link_content.html_safe, {:controller => :users, :action => :edit_self}, {:class => 'btn navbar-btn'}) %>
-      <a class="btn btn-default navbar-btn border-left dropdown-toggle last" id="user-menu-dropdown" data-bs-toggle="dropdown" href="#" title="<%= I18n.t("navbar.global_settings") %>" aria-label="<%= I18n.t("navbar.global_settings") %>"><span class="caret"></span></a>
+      <a class="btn btn-default navbar-btn border-start dropdown-toggle last" id="user-menu-dropdown" data-bs-toggle="dropdown" href="#" title="<%= I18n.t("navbar.global_settings") %>" aria-label="<%= I18n.t("navbar.global_settings") %>"><span class="caret"></span></a>
       <ul class="dropdown-menu dropdown-menu-right float-xs-right">
         <li class='dropdown-item'><%= link_to I18n.t("navbar.global_preferences") + " (#{username})", :controller => :preferences, :action => :edit, :id => 0, :global => true %></li>
         <li class='dropdown-item'><%= link_to I18n.t("navbar.user_repo_preferences") + " (#{username})", :controller => :preferences, :action => :edit, :id => 0 %></li>

--- a/frontend/app/views/shared/_header_user.html.erb
+++ b/frontend/app/views/shared/_header_user.html.erb
@@ -20,7 +20,7 @@
   <% end %>
   <li class="dropdown system-menu px-4">
     <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown"><%= I18n.t("navbar.global_admin") %> <b class="caret"></b></a>
-    <ul class="dropdown-menu dropdown-menu-right">
+    <ul class="dropdown-menu dropdown-menu-end">
       <% if user_can?('update_enumeration_record') %>
         <li class='dropdown-item'><%= link_to I18n.t("navbar.manage_enumerations"), :controller => :enumerations, :action => :index %></li>
       <% end %>
@@ -58,7 +58,7 @@
   <% if Plugins.system_menu_items.any? {|plugin| has_permission_for_controller?(session, plugin)} %>
     <li class="dropdown plugin-container">
       <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown"><%= I18n.t("navbar.plugins") %> <b class="caret"></b></a>
-      <ul class="dropdown-menu dropdown-menu-right">
+      <ul class="dropdown-menu dropdown-menu-end">
         <% Plugins.system_menu_items.each do |plugin| %>
           <% if has_permission_for_controller?(session, plugin) %>
             <li class='dropdown-item'><%= link_to I18n.t("plugins.#{plugin}.label"), :controller => plugin.intern, :action => :index %></li>
@@ -73,7 +73,7 @@
       <% link_content = "<span class='glyphicon glyphicon-user'></span>&nbsp;<span class='user-label'>#{session[:user]}</span>" %>
       <%= link_to(link_content.html_safe, {:controller => :users, :action => :edit_self}, {:class => 'btn navbar-btn'}) %>
       <a class="btn btn-default navbar-btn border-start dropdown-toggle last" id="user-menu-dropdown" data-bs-toggle="dropdown" href="#" title="<%= I18n.t("navbar.global_settings") %>" aria-label="<%= I18n.t("navbar.global_settings") %>"><span class="caret"></span></a>
-      <ul class="dropdown-menu dropdown-menu-right float-xs-right">
+      <ul class="dropdown-menu dropdown-menu-end float-xs-right">
         <li class='dropdown-item'><%= link_to I18n.t("navbar.global_preferences") + " (#{username})", :controller => :preferences, :action => :edit, :id => 0, :global => true %></li>
         <li class='dropdown-item'><%= link_to I18n.t("navbar.user_repo_preferences") + " (#{username})", :controller => :preferences, :action => :edit, :id => 0 %></li>
         <% if user_can?('administer_system') || user_can?('manage_repository') %>

--- a/frontend/app/views/shared/_header_user.html.erb
+++ b/frontend/app/views/shared/_header_user.html.erb
@@ -3,7 +3,7 @@
 <% if session[:user] %>
   <% if @repositories.length > 0 %>
     <li class="dropdown select-a-repository px-4">
-      <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= I18n.t("repository._frontend.action.select") %> <b class="caret"></b></a>
+      <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown"><%= I18n.t("repository._frontend.action.select") %> <b class="caret"></b></a>
       <ul class="dropdown-menu" style="padding: 15px;">
         <li class='dropdown-item'>
           <%= form_tag({:controller => :repositories, :action => :select}) do |f| %>
@@ -19,7 +19,7 @@
     </li>
   <% end %>
   <li class="dropdown system-menu px-4">
-    <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= I18n.t("navbar.global_admin") %> <b class="caret"></b></a>
+    <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown"><%= I18n.t("navbar.global_admin") %> <b class="caret"></b></a>
     <ul class="dropdown-menu dropdown-menu-right">
       <% if user_can?('update_enumeration_record') %>
         <li class='dropdown-item'><%= link_to I18n.t("navbar.manage_enumerations"), :controller => :enumerations, :action => :index %></li>
@@ -57,7 +57,7 @@
 
   <% if Plugins.system_menu_items.any? {|plugin| has_permission_for_controller?(session, plugin)} %>
     <li class="dropdown plugin-container">
-      <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= I18n.t("navbar.plugins") %> <b class="caret"></b></a>
+      <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown"><%= I18n.t("navbar.plugins") %> <b class="caret"></b></a>
       <ul class="dropdown-menu dropdown-menu-right">
         <% Plugins.system_menu_items.each do |plugin| %>
           <% if has_permission_for_controller?(session, plugin) %>
@@ -72,7 +72,7 @@
     <div class="btn-group bg-white align-items-center border rounded">
       <% link_content = "<span class='glyphicon glyphicon-user'></span>&nbsp;<span class='user-label'>#{session[:user]}</span>" %>
       <%= link_to(link_content.html_safe, {:controller => :users, :action => :edit_self}, {:class => 'btn navbar-btn'}) %>
-      <a class="btn btn-default navbar-btn border-left dropdown-toggle last" id="user-menu-dropdown" data-toggle="dropdown" href="#" title="<%= I18n.t("navbar.global_settings") %>" aria-label="<%= I18n.t("navbar.global_settings") %>"><span class="caret"></span></a>
+      <a class="btn btn-default navbar-btn border-left dropdown-toggle last" id="user-menu-dropdown" data-bs-toggle="dropdown" href="#" title="<%= I18n.t("navbar.global_settings") %>" aria-label="<%= I18n.t("navbar.global_settings") %>"><span class="caret"></span></a>
       <ul class="dropdown-menu dropdown-menu-right float-xs-right">
         <li class='dropdown-item'><%= link_to I18n.t("navbar.global_preferences") + " (#{username})", :controller => :preferences, :action => :edit, :id => 0, :global => true %></li>
         <li class='dropdown-item'><%= link_to I18n.t("navbar.user_repo_preferences") + " (#{username})", :controller => :preferences, :action => :edit, :id => 0 %></li>

--- a/frontend/app/views/shared/_header_user.html.erb
+++ b/frontend/app/views/shared/_header_user.html.erb
@@ -8,7 +8,7 @@
         <li class='dropdown-item'>
           <%= form_tag({:controller => :repositories, :action => :select}) do |f| %>
             <fieldset>
-              <label for="id" class="sr-only"><%= I18n.t('repository._frontend.action.select') %></label>
+              <label for="id" class="visually-hidden"><%= I18n.t('repository._frontend.action.select') %></label>
               <%= select_tag "id", options_for_select(@repositories.map {|repo| [repo.repo_code, repo.id]}, session[:repo_id]), :class=>"form-control" %>
             </fieldset>
             <br />

--- a/frontend/app/views/shared/_linker.html.erb
+++ b/frontend/app/views/shared/_linker.html.erb
@@ -86,7 +86,7 @@
       <% end %>
 
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("agent.linker.link_title") %>"><span class="caret"></span></a>
+        <a class="btn btn-default dropdown-toggle last" data-bs-toggle="dropdown" href="javascript:void(0);" aria-label="<%= I18n.t("agent.linker.link_title") %>"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
           <% if user_can?('update_agent_record') %>

--- a/frontend/app/views/shared/_merge_dropdown.html.erb
+++ b/frontend/app/views/shared/_merge_dropdown.html.erb
@@ -8,7 +8,7 @@
     <button class="btn btn-sm btn-default dropdown-toggle merge-action" data-bs-toggle="dropdown" role="button" aria-expanded="false" title="<%= I18n.t("actions.merge") %>">
       <%= I18n.t("actions.merge") %> <span class="caret"></span>
     </button>
-    <ul class="dropdown-menu merge-form dropdown-menu-right" role="none">
+    <ul class="dropdown-menu merge-form dropdown-menu-end" role="none">
       <li>
       <p><%= I18n.t("#{singular}._frontend.messages.merge_description") %>   <%= record.title %></p>
         <%= form_context :merge, {} do |form| %>

--- a/frontend/app/views/shared/_merge_dropdown.html.erb
+++ b/frontend/app/views/shared/_merge_dropdown.html.erb
@@ -5,7 +5,7 @@
 %>
 
   <div id="merge-dropdown" class="btn-group dropdown" data-no-change-tracking="true">
-    <button class="btn btn-sm btn-default dropdown-toggle merge-action" data-toggle="dropdown" role="button" aria-expanded="false" title="<%= I18n.t("actions.merge") %>">
+    <button class="btn btn-sm btn-default dropdown-toggle merge-action" data-bs-toggle="dropdown" role="button" aria-expanded="false" title="<%= I18n.t("actions.merge") %>">
       <%= I18n.t("actions.merge") %> <span class="caret"></span>
     </button>
     <ul class="dropdown-menu merge-form dropdown-menu-right" role="none">

--- a/frontend/app/views/shared/_merge_dropdown.html.erb
+++ b/frontend/app/views/shared/_merge_dropdown.html.erb
@@ -29,7 +29,7 @@
                                      :"data-confirm-btn-class" => "btn btn-default"
                                    })
           %>
-          <a class="btn btn-cancel btn-default pull-right ml-auto btn-danger" href="#"><%= I18n.t("actions.cancel") %></a>
+          <a class="btn btn-cancel btn-default pull-right ms-auto btn-danger" href="#"><%= I18n.t("actions.cancel") %></a>
         </div>
         <% end %>
       </li>

--- a/frontend/app/views/shared/_multiselect.html.erb
+++ b/frontend/app/views/shared/_multiselect.html.erb
@@ -1,4 +1,4 @@
 <label>
-  <span class="sr-only"><%= I18n.t("search_results.selected") %></span>
+  <span class="visually-hidden"><%= I18n.t("search_results.selected") %></span>
   <%= check_box_tag "multiselect-item", record["id"], false, "autocomplete" => "off", "data-display-string" => "#{clean_mixed_content(record["title"]).html_safe || clean_mixed_content(record['display_string']).html_safe}" %>
 </label>

--- a/frontend/app/views/shared/_pagination_summary.html.erb
+++ b/frontend/app/views/shared/_pagination_summary.html.erb
@@ -8,7 +8,7 @@
       <span class="btn-group align-items-baseline">
         <label>,&#160;<%= I18n.t("search_sorting.sort_by") %>&#160;</label>
         <div class="btn-group align-items-center">
-          <a class="dropdown-toggle border bg-white rounded d-flex align-items-center pr-3" data-toggle="dropdown" href="#">
+          <a class="dropdown-toggle border bg-white rounded d-flex align-items-center pr-3" data-bs-toggle="dropdown" href="#">
             <span class="btn"><%= @search_data.sorted_by_label %></span>
           </a>
           <ul class="dropdown-menu">
@@ -34,7 +34,7 @@
       <span class="btn-group align-items-baseline">
         <label>&#160;<%= I18n.t("search_sorting.and") %>&#160;</label>
         <div class="btn-group">
-          <a class="dropdown-toggle border bg-white rounded d-flex align-items-center pr-3" data-toggle="dropdown" href="#">
+          <a class="dropdown-toggle border bg-white rounded d-flex align-items-center pr-3" data-bs-toggle="dropdown" href="#">
               <span class="btn"><%= @search_data.sorted_by_label(1) %></span>
           </a>
           <ul class="dropdown-menu">

--- a/frontend/app/views/shared/_pagination_summary.html.erb
+++ b/frontend/app/views/shared/_pagination_summary.html.erb
@@ -8,7 +8,7 @@
       <span class="btn-group align-items-baseline">
         <label>,&#160;<%= I18n.t("search_sorting.sort_by") %>&#160;</label>
         <div class="btn-group align-items-center">
-          <a class="dropdown-toggle border bg-white rounded d-flex align-items-center pr-3" data-bs-toggle="dropdown" href="#">
+          <a class="dropdown-toggle border bg-white rounded d-flex align-items-center pe-3" data-bs-toggle="dropdown" href="#">
             <span class="btn"><%= @search_data.sorted_by_label %></span>
           </a>
           <ul class="dropdown-menu">
@@ -34,7 +34,7 @@
       <span class="btn-group align-items-baseline">
         <label>&#160;<%= I18n.t("search_sorting.and") %>&#160;</label>
         <div class="btn-group">
-          <a class="dropdown-toggle border bg-white rounded d-flex align-items-center pr-3" data-bs-toggle="dropdown" href="#">
+          <a class="dropdown-toggle border bg-white rounded d-flex align-items-center pe-3" data-bs-toggle="dropdown" href="#">
               <span class="btn"><%= @search_data.sorted_by_label(1) %></span>
           </a>
           <ul class="dropdown-menu">

--- a/frontend/app/views/shared/_rde.html.erb
+++ b/frontend/app/views/shared/_rde.html.erb
@@ -27,7 +27,7 @@
         <p>
         <div class="btn-group">
           <button class="btn btn-sm btn-success add-row"><%= I18n.t("rde.actions.add_row") %></button>
-          <button class="btn btn-sm btn-success dropdown-toggle add-rows-dropdown" data-toggle="dropdown">
+          <button class="btn btn-sm btn-success dropdown-toggle add-rows-dropdown" data-bs-toggle="dropdown">
             <span class="caret"></span>
           </button>
 
@@ -196,7 +196,7 @@
         <div>
           <div class="btn-group">
             <button class="btn btn-sm btn-success add-row"><%= I18n.t("rde.actions.add_row") %></button>
-            <button class="btn btn-sm btn-success dropdown-toggle add-rows-dropdown" data-toggle="dropdown">
+            <button class="btn btn-sm btn-success dropdown-toggle add-rows-dropdown" data-bs-toggle="dropdown">
               <span class="caret"></span>
             </button>
             <div class="dropdown-menu add-rows-form">

--- a/frontend/app/views/shared/_resource_toolbar.html.erb
+++ b/frontend/app/views/shared/_resource_toolbar.html.erb
@@ -54,7 +54,7 @@
             </div>
           <% end %>
           <div class="btn-group border">
-            <a class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);">
+            <a class="btn btn-sm btn-default dropdown-toggle" data-bs-toggle="dropdown" href="javascript:void(0);">
               <%= I18n.t("actions.export") %>
               <span class="caret"></span>
             </a>
@@ -88,7 +88,7 @@
             </div>
           <% end %>
           <div class="btn-group dropdown border" id="other-dropdown" style="display: none">
-            <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+            <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
               <%= I18n.t('actions.more') %>
               <span class="caret"></span>
             </button>

--- a/frontend/app/views/shared/_resource_toolbar.html.erb
+++ b/frontend/app/views/shared/_resource_toolbar.html.erb
@@ -58,7 +58,7 @@
               <%= I18n.t("actions.export") %>
               <span class="caret"></span>
             </a>
-            <ul class="dropdown-menu dropdown-menu-right">
+            <ul class="dropdown-menu dropdown-menu-end">
               <%= yield :exports %>
             </ul>
           </div>

--- a/frontend/app/views/shared/_resource_toolbar.html.erb
+++ b/frontend/app/views/shared/_resource_toolbar.html.erb
@@ -17,7 +17,7 @@
           <%= I18n.t("actions.toolbar_disabled_message") %>
         </div>
       <% end %>
-      <div class="btn-toolbar bg-white ml-auto">
+      <div class="btn-toolbar bg-white ms-auto">
         <div class="btn-group">
           <% if user_can?('update_event_record') && !record.suppressed %>
             <div class="border d-flex">

--- a/frontend/app/views/shared/_subrecord_form.html.erb
+++ b/frontend/app/views/shared/_subrecord_form.html.erb
@@ -43,7 +43,7 @@
      <% if custom_action_template %>
        <%= render :partial => custom_action_template %>
      <% else %>
-       <button class="btn btn-sm btn-default float-end bg-white border mt-1 mr-1"><%= I18n.t("#{i18n_prefix}#{action_button_override}._frontend.action.add") %></button>
+       <button class="btn btn-sm btn-default float-end bg-white border mt-1 me-1"><%= I18n.t("#{i18n_prefix}#{action_button_override}._frontend.action.add") %></button>
      <% end %>
     <% end %>
 

--- a/frontend/app/views/shared/_subrecord_form.html.erb
+++ b/frontend/app/views/shared/_subrecord_form.html.erb
@@ -43,7 +43,7 @@
      <% if custom_action_template %>
        <%= render :partial => custom_action_template %>
      <% else %>
-       <button class="btn btn-sm btn-default float-right bg-white border mt-1 mr-1"><%= I18n.t("#{i18n_prefix}#{action_button_override}._frontend.action.add") %></button>
+       <button class="btn btn-sm btn-default float-end bg-white border mt-1 mr-1"><%= I18n.t("#{i18n_prefix}#{action_button_override}._frontend.action.add") %></button>
      <% end %>
     <% end %>
 

--- a/frontend/app/views/shared/_templates.html.erb
+++ b/frontend/app/views/shared/_templates.html.erb
@@ -4,7 +4,7 @@
        <div class="modal-content">
          {if defined("title") && title.length > 0}
            <div class="modal-header align-items-center">
-             <a class="close m-0 mr-auto" data-dismiss="modal">×</a>
+             <a class="close m-0 me-auto" data-dismiss="modal">×</a>
              <h3>${title|h}</h3>
            </div>
          {/if}
@@ -294,7 +294,7 @@
 --></div>
 
 <div id="template_subrecord_collapse_action"><!--
-  <button class="btn btn-xs pull-right ml-auto collapse-subrecord-toggle">
+  <button class="btn btn-xs pull-right ms-auto collapse-subrecord-toggle">
     <span class="expand"><%= I18n.t("note._frontend.action.expand")%></span>
     <span class="collapse"><%= I18n.t("note._frontend.action.collapse")%></span>
   </button>

--- a/frontend/app/views/shared/_toolbar_new_records.html.erb
+++ b/frontend/app/views/shared/_toolbar_new_records.html.erb
@@ -3,7 +3,7 @@
     <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
   </div>
   <% if controller_name == "agents" && full_mode? %>
-    <div class="btn-toolbar ml-auto">
+    <div class="btn-toolbar ms-auto">
       <div class="btn-group">
         <%= render_aspace_partial :partial => "shared/lightmode_toggle", :locals => {:type => 'agents'} %>
       </div>

--- a/frontend/app/views/shared/_transfer_dropdown.html.erb
+++ b/frontend/app/views/shared/_transfer_dropdown.html.erb
@@ -15,7 +15,7 @@
         <p><%= I18n.t("#{singular}._frontend.messages.transfer_description") %></p>
         <%= form_context :transfer, {} do |form| %>
         <fieldset>
-          <legend class="sr-only">Transfer to this repository:</legend>
+          <legend class="visually-hidden">Transfer to this repository:</legend>
           <div class="alert alert-danger missing-ref-message" style="display: none;"><%= I18n.t "#{singular}._frontend.messages.transfer_target" %></div>
           <%= form.label_and_select "ref", other_repositories, :layout => 'stacked' %>
         </fieldset>

--- a/frontend/app/views/shared/_transfer_dropdown.html.erb
+++ b/frontend/app/views/shared/_transfer_dropdown.html.erb
@@ -24,14 +24,14 @@
              button_confirm_action(I18n.t("actions.transfer"),
                                    url_for({:controller => controller, :action => :transfer, :id => record.id}.merge(extra_params)),
                                    {
-                                     :class => "btn mr-auto transfer-button border",
+                                     :class => "btn me-auto transfer-button border",
                                      :"data-title" => confirmation_title,
                                      :"data-message" => confirmation_msg,
                                      :"data-confirm-btn-label" => "#{I18n.t("actions.transfer")}",
                                      :"data-confirm-btn-class" => "btn"
                                    })
           %>
-          <a class="btn ml-auto btn-danger" href="#"><%= I18n.t("actions.cancel") %></a>
+          <a class="btn ms-auto btn-danger" href="#"><%= I18n.t("actions.cancel") %></a>
         </div>
         <% end %>
       </li>

--- a/frontend/app/views/shared/_transfer_dropdown.html.erb
+++ b/frontend/app/views/shared/_transfer_dropdown.html.erb
@@ -7,7 +7,7 @@
 
 <% if !other_repositories.empty? %>
   <div id="transfer-dropdown" class="btn-group dropdown d-flex" data-no-change-tracking="true">
-    <button class="btn btn-sm btn-default dropdown-toggle transfer-action" data-toggle="dropdown" role="button" aria-expanded="false" title="<%= I18n.t("actions.transfer") %>">
+    <button class="btn btn-sm btn-default dropdown-toggle transfer-action" data-bs-toggle="dropdown" role="button" aria-expanded="false" title="<%= I18n.t("actions.transfer") %>">
       <%= I18n.t("actions.transfer") %> <span class="caret"></span>
     </button>
     <ul class="dropdown-menu dropdown-menu-right transfer-form" role="none">

--- a/frontend/app/views/shared/_transfer_dropdown.html.erb
+++ b/frontend/app/views/shared/_transfer_dropdown.html.erb
@@ -10,7 +10,7 @@
     <button class="btn btn-sm btn-default dropdown-toggle transfer-action" data-bs-toggle="dropdown" role="button" aria-expanded="false" title="<%= I18n.t("actions.transfer") %>">
       <%= I18n.t("actions.transfer") %> <span class="caret"></span>
     </button>
-    <ul class="dropdown-menu dropdown-menu-right transfer-form" role="none">
+    <ul class="dropdown-menu dropdown-menu-end transfer-form" role="none">
       <li>
         <p><%= I18n.t("#{singular}._frontend.messages.transfer_description") %></p>
         <%= form_context :transfer, {} do |form| %>

--- a/frontend/app/views/space_calculator/_form.html.erb
+++ b/frontend/app/views/space_calculator/_form.html.erb
@@ -88,7 +88,7 @@
                        data-types='["location"]'
                 />
                 <div class="input-group-btn">
-                  <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);"><span class="caret"></span></a>
+                  <a class="btn btn-default dropdown-toggle last" data-bs-toggle="dropdown" href="javascript:void(0);"><span class="caret"></span></a>
                   <ul class="dropdown-menu">
                     <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
                   </ul>

--- a/frontend/app/views/subjects/_linker.html.erb
+++ b/frontend/app/views/subjects/_linker.html.erb
@@ -99,7 +99,7 @@
           <div class="input-group-btn">
              <a class="btn btn-default dropdown-toggle last d-flex align-items-center border-dark border-start-0"  href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Link to subject" id="dropdownMenuSubjectsToggle">
             </a>
-              <ul class="dropdown-menu dropdown-menu-right" id='dropdownMenuSubjects' aria-labelledby="#dropdownMenuSubjects">
+              <ul class="dropdown-menu dropdown-menu-end" id='dropdownMenuSubjects' aria-labelledby="#dropdownMenuSubjects">
                  <li class='dropdown-item'>
                   <a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a>
                 </li>

--- a/frontend/app/views/subjects/_linker.html.erb
+++ b/frontend/app/views/subjects/_linker.html.erb
@@ -97,7 +97,7 @@
           <% end %>
           
           <div class="input-group-btn">
-             <a class="btn btn-default dropdown-toggle last d-flex align-items-center border-dark border-left-0"  href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Link to subject" id="dropdownMenuSubjectsToggle">
+             <a class="btn btn-default dropdown-toggle last d-flex align-items-center border-dark border-start-0"  href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Link to subject" id="dropdownMenuSubjectsToggle">
             </a>
               <ul class="dropdown-menu dropdown-menu-right" id='dropdownMenuSubjects' aria-labelledby="#dropdownMenuSubjects">
                  <li class='dropdown-item'>

--- a/frontend/app/views/subjects/_linker.html.erb
+++ b/frontend/app/views/subjects/_linker.html.erb
@@ -97,7 +97,7 @@
           <% end %>
           
           <div class="input-group-btn">
-             <a class="btn btn-default dropdown-toggle last d-flex align-items-center border-dark border-left-0"  href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Link to subject" id="dropdownMenuSubjectsToggle">
+             <a class="btn btn-default dropdown-toggle last d-flex align-items-center border-dark border-left-0"  href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Link to subject" id="dropdownMenuSubjectsToggle">
             </a>
               <ul class="dropdown-menu dropdown-menu-right" id='dropdownMenuSubjects' aria-labelledby="#dropdownMenuSubjects">
                  <li class='dropdown-item'>

--- a/frontend/app/views/subjects/_linker.html.erb
+++ b/frontend/app/views/subjects/_linker.html.erb
@@ -43,7 +43,7 @@
 <div class="form-group required">
    <% if !name.blank? %>
      <%= wrap_with_tooltip(linker_label, "#{form.i18n_for(name)}_tooltip", "subrecord-form-heading-label control-label col-sm-2") %>
-     <label class="sr-only"
+     <label class="visually-hidden"
             id="<%= form.id_for(data_name) %>_label"
             for="<%= form.id_for(data_name) %>">
         <%= linker_label %>

--- a/frontend/app/views/subjects/_toolbar.html.erb
+++ b/frontend/app/views/subjects/_toolbar.html.erb
@@ -5,7 +5,7 @@
         <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
       </div>
     <% else %>
-      <div class="btn-group mr-auto">
+      <div class="btn-group me-auto">
         <%= link_to I18n.t("actions.edit"), {:controller => :subjects, :action => :edit, :id => @subject.id}, :class => "btn btn-sm btn-primary" %>
       </div>
     <% end %>
@@ -17,7 +17,7 @@
       </div>
     <% end %>
 
-    <div class="btn-group btn-toolbar ml-auto align-items-center bg-white border rounded">
+    <div class="btn-group btn-toolbar ms-auto align-items-center bg-white border rounded">
       <% if user_can?('merge_subject_record') %>
         <%=
         render_aspace_partial :partial => "shared/merge_dropdown",

--- a/frontend/app/views/subjects/index.html.erb
+++ b/frontend/app/views/subjects/index.html.erb
@@ -9,7 +9,7 @@
   <div class="col-md-9">
     <% if user_can?('update_subject_record') %>
       <div class="record-toolbar d-flex align-items-center">
-        <div class="btn-group ml-auto bg-white border rounded">
+        <div class="btn-group ms-auto bg-white border rounded">
           <% if user_can?('manage_repository') %>
               <%= link_to I18n.t("actions.edit_default_values"), {:controller => :subjects, :action => :defaults}, :class => "btn btn-sm btn-default" %>
           <% end %>

--- a/frontend/app/views/system_info/_navbar.html.erb
+++ b/frontend/app/views/system_info/_navbar.html.erb
@@ -4,7 +4,7 @@
   <div class="navbar-inner">
     <ul class="navbar-nav">
       <li class='nav-itm dropdown mx-3'>
-      <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);">
+      <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="javascript:void(0);">
         <%= I18n.t("system_info.frontend") %>
       </a>
         <ul class='dropdown-menu'>
@@ -14,7 +14,7 @@
       </li>
       
       <li class='nav-item dropdown'>
-      <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);">
+      <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="javascript:void(0);">
         <%= I18n.t("system_info.backend") %>
       </a>
         <ul class='dropdown-menu'>

--- a/frontend/app/views/top_containers/_linker.html.erb
+++ b/frontend/app/views/top_containers/_linker.html.erb
@@ -83,7 +83,7 @@
 
 
       <div class="input-group-btn">
-        <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("top_container.linker.link_title") %>" aria-label="<%= I18n.t("top_container.linker.link_title") %>"><span class="caret"></span></a>
+        <a class="btn btn-default dropdown-toggle last" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("top_container.linker.link_title") %>" aria-label="<%= I18n.t("top_container.linker.link_title") %>"><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
           <% if allow_create && user_can?('update_container_record') %>

--- a/frontend/app/views/top_containers/_toolbar.html.erb
+++ b/frontend/app/views/top_containers/_toolbar.html.erb
@@ -13,7 +13,7 @@
       </div>
     <% end %>
     <% if !['new'].include?(controller.action_name) && user_can?('manage_container_record') %>
-      <div class="btn-toolbar ml-auto">
+      <div class="btn-toolbar ms-auto">
         <div class="btn-group">
           <div class="btn btn-inline-form">
             <%= button_delete_action url_for(:controller => :top_containers, :action => :delete, :id => @top_container.id ), { :"data-title" => I18n.t("actions.delete_confirm_title", :title => @top_container.display_string) } unless @top_container.id.nil? %> 

--- a/frontend/app/views/top_containers/bulk_operations/_collection_accession_linker.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_collection_accession_linker.erb
@@ -24,7 +24,7 @@
          data-types='<%= ['accession'].to_json %>'
   />
   <div class="input-group-btn">
-    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("top_container._frontend.bulk_operations.collection_accession.link_title") %>" aria-label="<%= I18n.t("top_container._frontend.bulk_operations.collection_accession.link_title") %>"></a>
+    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-start-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("top_container._frontend.bulk_operations.collection_accession.link_title") %>" aria-label="<%= I18n.t("top_container._frontend.bulk_operations.collection_accession.link_title") %>"></a>
     <ul class="dropdown-menu">
       <li class='dropdown-item'><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
     </ul>

--- a/frontend/app/views/top_containers/bulk_operations/_collection_accession_linker.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_collection_accession_linker.erb
@@ -24,7 +24,7 @@
          data-types='<%= ['accession'].to_json %>'
   />
   <div class="input-group-btn">
-    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-left-0 d-flex align-items-center" data-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("top_container._frontend.bulk_operations.collection_accession.link_title") %>" aria-label="<%= I18n.t("top_container._frontend.bulk_operations.collection_accession.link_title") %>"></a>
+    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("top_container._frontend.bulk_operations.collection_accession.link_title") %>" aria-label="<%= I18n.t("top_container._frontend.bulk_operations.collection_accession.link_title") %>"></a>
     <ul class="dropdown-menu">
       <li class='dropdown-item'><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
     </ul>

--- a/frontend/app/views/top_containers/bulk_operations/_collection_resource_linker.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_collection_resource_linker.erb
@@ -24,7 +24,7 @@
          data-types='<%= ['resource'].to_json %>'
   />
   <div class="input-group-btn">
-    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("top_container._frontend.bulk_operations.collection_resource.link_title") %>" aria-label="<%= I18n.t("top_container._frontend.bulk_operations.collection_resource.create") %>"></span></a>
+    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-start-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("top_container._frontend.bulk_operations.collection_resource.link_title") %>" aria-label="<%= I18n.t("top_container._frontend.bulk_operations.collection_resource.create") %>"></span></a>
     <ul class="dropdown-menu">
       <li class='dropdown-item'><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
     </ul>

--- a/frontend/app/views/top_containers/bulk_operations/_collection_resource_linker.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_collection_resource_linker.erb
@@ -24,7 +24,7 @@
          data-types='<%= ['resource'].to_json %>'
   />
   <div class="input-group-btn">
-    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-left-0 d-flex align-items-center" data-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("top_container._frontend.bulk_operations.collection_resource.link_title") %>" aria-label="<%= I18n.t("top_container._frontend.bulk_operations.collection_resource.create") %>"></span></a>
+    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("top_container._frontend.bulk_operations.collection_resource.link_title") %>" aria-label="<%= I18n.t("top_container._frontend.bulk_operations.collection_resource.create") %>"></span></a>
     <ul class="dropdown-menu">
       <li class='dropdown-item'><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
     </ul>

--- a/frontend/app/views/top_containers/bulk_operations/_container_profile_linker.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_container_profile_linker.html.erb
@@ -27,7 +27,7 @@
          data-types='<%= linkable_types.to_json %>'
   />
   <div class="input-group-btn">
-    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("container_profile.linker.link_title") %>" aria-label="<%= I18n.t("container_profile.linker.link_title") %>"></a>
+    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-start-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("container_profile.linker.link_title") %>" aria-label="<%= I18n.t("container_profile.linker.link_title") %>"></a>
     <ul class="dropdown-menu">
       <li class='dropdown-item'><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
       <% if show_create_link && user_can?('update_container_profile_record') %>

--- a/frontend/app/views/top_containers/bulk_operations/_container_profile_linker.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_container_profile_linker.html.erb
@@ -27,7 +27,7 @@
          data-types='<%= linkable_types.to_json %>'
   />
   <div class="input-group-btn">
-    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-left-0 d-flex align-items-center" data-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("container_profile.linker.link_title") %>" aria-label="<%= I18n.t("container_profile.linker.link_title") %>"></a>
+    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("container_profile.linker.link_title") %>" aria-label="<%= I18n.t("container_profile.linker.link_title") %>"></a>
     <ul class="dropdown-menu">
       <li class='dropdown-item'><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
       <% if show_create_link && user_can?('update_container_profile_record') %>

--- a/frontend/app/views/top_containers/bulk_operations/_location_linker.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_location_linker.html.erb
@@ -29,7 +29,7 @@
          data-types='<%= linkable_types.to_json %>'
   />
   <div class="input-group-btn">
-    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-left-0 d-flex align-items-center" data-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("location.linker.link_title") %>" aria-label="<%= I18n.t("location.linker.link_title") %>"></a>
+    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("location.linker.link_title") %>" aria-label="<%= I18n.t("location.linker.link_title") %>"></a>
     <ul class="dropdown-menu">
       <li class='dropdown-item'><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
       <% if show_create_link && user_can?('update_location_record') %>

--- a/frontend/app/views/top_containers/bulk_operations/_location_linker.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_location_linker.html.erb
@@ -29,7 +29,7 @@
          data-types='<%= linkable_types.to_json %>'
   />
   <div class="input-group-btn">
-    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-left-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("location.linker.link_title") %>" aria-label="<%= I18n.t("location.linker.link_title") %>"></a>
+    <a class="btn btn-default dropdown-toggle last border-dark bg-white border-start-0 d-flex align-items-center" data-bs-toggle="dropdown" href="javascript:void(0);" title="<%= I18n.t("location.linker.link_title") %>" aria-label="<%= I18n.t("location.linker.link_title") %>"></a>
     <ul class="dropdown-menu">
       <li class='dropdown-item'><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
       <% if show_create_link && user_can?('update_location_record') %>

--- a/frontend/app/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_results.html.erb
@@ -92,7 +92,7 @@
 
         <% if show_edit_actions %>
         <td>
-          <div class="btn-group ml-auto bg-white border rounded">
+          <div class="btn-group ms-auto bg-white border rounded">
             <%= link_to I18n.t("actions.view"), {:controller => :resolver, :action => :resolve_readonly, :uri => container_json["uri"]}, :class => "btn" %>
             <% if can_edit %>
               <%= link_to I18n.t("actions.edit"), {:controller => :resolver, :action => :resolve_edit, :uri => container_json["uri"]}, :class => "btn btn-primary" %>

--- a/frontend/app/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_results.html.erb
@@ -23,7 +23,7 @@
 <table class="table table-striped table-bordered table-condensed table-hover table-sortable table-search-results table-responsive">
   <thead>
     <tr class="sortable-columns">
-      <th><% if multiselect %><label for="select_all" class="sr-only"><%= I18n.t("search_results.selected") %></label><%= check_box_tag "select_all" %><% end %></th>
+      <th><% if multiselect %><label for="select_all" class="visually-hidden"><%= I18n.t("search_results.selected") %></label><%= check_box_tag "select_all" %><% end %></th>
       <th><%= I18n.t("top_container._frontend.bulk_operations.collection_singular") %></th>
       <th><%= I18n.t("top_container._frontend.bulk_operations.series") %></th>
       <th><%= I18n.t("container_profile._singular") %></th>
@@ -34,7 +34,7 @@
       <th><%= I18n.t("top_container.ils_holding_id") %></th>
       <th><%= I18n.t("top_container.restricted") %></th>
       <th><%= I18n.t("top_container.exported_to_ils") %></th>
-      <% if show_edit_actions %><th class="col actions"><span class="sr-only"><%= I18n.t("search_results.actions") %></span><!-- Actions --></th><% end %>
+      <% if show_edit_actions %><th class="col actions"><span class="visually-hidden"><%= I18n.t("search_results.actions") %></span><!-- Actions --></th><% end %>
     </tr>
   </thead>
   <tbody>
@@ -44,7 +44,7 @@
         <td>
           <% if multiselect %>
           <label>
-            <span class="sr-only"><%= I18n.t("search_results.selected") %></span>
+            <span class="visually-hidden"><%= I18n.t("search_results.selected") %></span>
             <%= check_box_tag "uri", container_json['uri'], false, :"data-display-string" => doc['title'], :"data-container-profile-uri" => doc['container_profile_uri_u_sstr'] %>
           </label>
           <% else %>

--- a/frontend/app/views/top_containers/bulk_operations/_toolbar.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_toolbar.html.erb
@@ -1,14 +1,14 @@
 <div class="record-toolbar bulk-operation-toolbar d-flex align-items-center">
-  <div class="btn-toolbar ml-auto">
+  <div class="btn-toolbar ms-auto">
     <%= link_to I18n.t("actions.export_csv"), request.parameters.merge({ :format => :csv, :fields =>
-        fields }), class: "searchExport btn btn-sm btn-info ml-auto" %>
-    <div class="bulk-actions ml-auto" class="btn-group">
+        fields }), class: "searchExport btn btn-sm btn-info ms-auto" %>
+    <div class="bulk-actions ms-auto" class="btn-group">
       <% if user_can?('manage_container_record') %>
       <a class="btn btn-sm btn-default dropdown-toggle" data-bs-toggle="dropdown" href="#">
         <%= I18n.t("top_container._frontend.bulk_operations.title") %>
         <span class="caret"></span>
       </a>
-      <ul class="dropdown-menu ml-auto">
+      <ul class="dropdown-menu ms-auto">
         <li><a id="bulkActionUpdateIlsHolding" href="javascript:void(0)"><%= I18n.t("top_container._frontend.bulk_operations.update_ils_holding_ids")%></a></li>
         <li><a id="bulkActionUpdateContainerProfile" href="javascript:void(0)"><%= I18n.t("top_container._frontend.bulk_operations.update_container_profiles")%></a></li>
         <li><a id="bulkActionUpdateLocation" href="javascript:void(0)"><%= I18n.t("top_container._frontend.bulk_operations.update_locations_singular")%></a></li>

--- a/frontend/app/views/top_containers/bulk_operations/_toolbar.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_toolbar.html.erb
@@ -4,7 +4,7 @@
         fields }), class: "searchExport btn btn-sm btn-info ml-auto" %>
     <div class="bulk-actions ml-auto" class="btn-group">
       <% if user_can?('manage_container_record') %>
-      <a class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" href="#">
+      <a class="btn btn-sm btn-default dropdown-toggle" data-bs-toggle="dropdown" href="#">
         <%= I18n.t("top_container._frontend.bulk_operations.title") %>
         <span class="caret"></span>
       </a>

--- a/frontend/app/views/users/_toolbar.html.erb
+++ b/frontend/app/views/users/_toolbar.html.erb
@@ -14,7 +14,7 @@
       <%= I18n.t("actions.toolbar_disabled_message") %>
     </div>
   <% end %>
-  <div class="btn-toolbar ml-auto">
+  <div class="btn-toolbar ms-auto">
     <% if @user.id && !@user.is_system_user && @user.username.downcase != current_user.downcase %>
       <div class="btn-group">
         <div class="btn btn-inline-form">

--- a/frontend/app/views/users/index.html.erb
+++ b/frontend/app/views/users/index.html.erb
@@ -44,7 +44,7 @@
                <th><%= I18n.t("user.admin") %></th>
                <th><%= I18n.t("user.is_active_user") %></th>
              <% end %>
-             <th width="70px"><span class="sr-only"><%= I18n.t('search_results.actions') %></span></th>
+             <th width="70px"><span class="visually-hidden"><%= I18n.t('search_results.actions') %></span></th>
            </tr>
          </thead>
          <tbody>

--- a/frontend/app/views/users/index.html.erb
+++ b/frontend/app/views/users/index.html.erb
@@ -4,7 +4,7 @@
    <div class="col-md-3"></div>
    <div class="col-md-9">
      <div class="record-toolbar d-flex align-items-center">
-       <div class="btn-group ml-auto">
+       <div class="btn-group ms-auto">
          <% unless @manage_access %>
            <%= link_to I18n.t("user._frontend.action.create"), {:controller => :users, :action => :new}, :class => "btn btn-sm btn-light border" %>
          <% end %>

--- a/frontend/vendor/assets/javascripts/bootstrap-multiselect.js
+++ b/frontend/vendor/assets/javascripts/bootstrap-multiselect.js
@@ -139,7 +139,7 @@
 
     // Templates.
     templates: {
-      button: '<button type="button" class="multiselect dropdown-toggle" data-toggle="dropdown"></button>',
+      button: '<button type="button" class="multiselect dropdown-toggle" data-bs-toggle="dropdown"></button>',
       ul: '<ul class="multiselect-container dropdown-menu"></ul>',
       filter: '<div class="input-group"><span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span><input class="form-control multiselect-search" type="text"></div>',
       li: '<li><a href="javascript:void(0);"><label></label></a></li>',

--- a/frontend/vendor/assets/javascripts/bootstrap-select.js
+++ b/frontend/vendor/assets/javascripts/bootstrap-select.js
@@ -288,7 +288,7 @@
       this.$searchbox = this.$menu.find('input');
 
       if (this.options.dropdownAlignRight)
-        this.$menu.addClass('dropdown-menu-right');
+        this.$menu.addClass('dropdown-menu-end');
 
       if (typeof id !== 'undefined') {
         this.$button.attr('data-id', id);

--- a/frontend/vendor/assets/javascripts/bootstrap-select.js
+++ b/frontend/vendor/assets/javascripts/bootstrap-select.js
@@ -348,7 +348,7 @@
           : '';
       var drop =
           '<div class="btn-group bootstrap-select' + multiple + inputGroup + '">' +
-          '<button type="button" class="btn dropdown-toggle" data-toggle="dropdown"' + autofocus + '>' +
+          '<button type="button" class="btn dropdown-toggle" data-bs-toggle="dropdown"' + autofocus + '>' +
           '<span class="filter-option pull-left"></span>&nbsp;' +
           '<span class="caret"></span>' +
           '</button>' +

--- a/plugins/lcnaf/frontend/views/lcnaf/index.html.erb
+++ b/plugins/lcnaf/frontend/views/lcnaf/index.html.erb
@@ -10,7 +10,7 @@
 
     <div class='control-group form-group required'>
       <fieldset>
-      <legend class="sr-only"><%= I18n.t("plugins.lcnaf.authority") %></legend>
+      <legend class="visually-hidden"><%= I18n.t("plugins.lcnaf.authority") %></legend>
         <div class="radio">
           <label for="lcnaf_service_loc">
             <input type="radio" name="lcnaf_service" value="lcnaf" id="lcnaf_service_loc" checked="true">

--- a/plugins/lcnaf/frontend/views/lcnaf/index.html.erb
+++ b/plugins/lcnaf/frontend/views/lcnaf/index.html.erb
@@ -82,9 +82,9 @@
     <div class="row">
       <div class="col-md-12">
         <div class='alert alert-info'>${record.title}
-          <span class="float-right alert alert-success btn-sm d-none"><%= I18n.t("plugins.lcnaf.messages.selected") %></span>
-          <button class="float-right btn btn-default d-none bg-white border mx-1 select-record" data-lccn="${record.lccn}"><%= I18n.t("plugins.lcnaf.actions.select") %></button>
-          <button class="float-right btn btn-default d-none bg-white border show-record mx-1" ><%= I18n.t("plugins.lcnaf.actions.show_record") %></button>
+          <span class="float-end alert alert-success btn-sm d-none"><%= I18n.t("plugins.lcnaf.messages.selected") %></span>
+          <button class="float-end btn btn-default d-none bg-white border mx-1 select-record" data-lccn="${record.lccn}"><%= I18n.t("plugins.lcnaf.actions.select") %></button>
+          <button class="float-end btn btn-default d-none bg-white border show-record mx-1" ><%= I18n.t("plugins.lcnaf.actions.show_record") %></button>
           <div class="col-md-12 lcnaf-marc d-none"><pre><code>${record.xml|h}</code></pre></div> 
         </div> 
       </div>   


### PR DESCRIPTION
# Summary
Replace all utilities classes: https://getbootstrap.com/docs/5.0/migration/#utilities
Replace all helpers classes: https://getbootstrap.com/docs/5.0/migration/#helpers
Replace all Javascript data-toggle attributes: 

In bootstrap 5, the dropdown-toggle attribute has been changed from data-toggle to data-bs-toggle as per the docs: https://getbootstrap.com/docs/5.0/components/dropdowns/

# Acceptance Criteria
- [ ] Dropdowns work throughout the app
- [ ] Margin left and right classes have been replaced
- [ ] sr-only is replaced with visually hidden
- [ ] text-right and text-left have been replaced with text-start and text-end