### PR TITLE
18n translation Failures: Error on create and edit pages

### DIFF
--- a/frontend/app/controllers/accessions_controller.rb
+++ b/frontend/app/controllers/accessions_controller.rb
@@ -48,7 +48,7 @@ class AccessionsController < ApplicationController
 
       if acc
         @accession.populate_from_accession(acc)
-        flash.now[:info] = t("accession._frontend.messages.spawned", accession_title: acc.title) 
+        flash.now[:info] = t("accession._frontend.messages.spawned", accession_display_string: acc.title) 
         flash[:spawned_from_accession] = acc.id
       end
     end
@@ -111,7 +111,7 @@ class AccessionsController < ApplicationController
                 :model => Accession,
                 :on_invalid => ->() { render action: "new" },
                 :on_valid => ->(id) {
-                    flash[:success] = t("accession._frontend.messages.created", accession_title: @accession.title) 
+                    flash[:success] = t("accession._frontend.messages.created", accession_display_string: @accession.title) 
                     if @accession["is_slug_auto"] == false &&
                        @accession["slug"] == nil &&
                        params["accession"] &&
@@ -132,7 +132,7 @@ class AccessionsController < ApplicationController
                   return render action: "edit"
                 },
                 :on_valid => ->(id) {
-                  flash[:success] = t("accession._frontend.messages.updated", accession_title: @accession.title) 
+                  flash[:success] = t("accession._frontend.messages.updated", accession_display_string: @accession.title) 
                   if @accession["is_slug_auto"] == false &&
                      @accession["slug"] == nil &&
                      params["accession"] &&
@@ -149,7 +149,7 @@ class AccessionsController < ApplicationController
     accession = Accession.find(params[:id])
     accession.set_suppressed(true)
 
-    flash[:success] = t("accession._frontend.messages.suppressed", accession_title: accession.title) 
+    flash[:success] = t("accession._frontend.messages.suppressed", accession_display_string: accession.title) 
     redirect_to(:controller => :accessions, :action => :show, :id => params[:id])
   end
 
@@ -158,7 +158,7 @@ class AccessionsController < ApplicationController
     accession = Accession.find(params[:id])
     accession.set_suppressed(false)
 
-    flash[:success] = t("accession._frontend.messages.unsuppressed", accession_title: accession.title) 
+    flash[:success] = t("accession._frontend.messages.unsuppressed", accession_display_string: accession.title) 
     redirect_to(:controller => :accessions, :action => :show, :id => params[:id])
   end
 
@@ -172,7 +172,7 @@ class AccessionsController < ApplicationController
       return redirect_to(:controller => :accessions, :action => :show, :id => params[:id])
     end
 
-    flash[:success] = t("accession._frontend.messages.deleted", accession_title: accession.title) 
+    flash[:success] = t("accession._frontend.messages.deleted", accession_display_string: accession.title) 
     redirect_to(:controller => :accessions, :action => :index, :deleted_uri => accession.uri)
   end
 

--- a/frontend/app/controllers/accessions_controller.rb
+++ b/frontend/app/controllers/accessions_controller.rb
@@ -29,13 +29,13 @@ class AccessionsController < ApplicationController
   end
 
   def show
-    event_hits = fetch_linked_events_count(:accession, params[:id])
+    event_hits = fetch_linked_events_count(:accession, params[:id]) 
     excludes = event_hits > AppConfig[:max_linked_events_to_resolve] ? ['linked_events', 'linked_events::linked_records'] : []
     @accession = fetch_resolved(:accession, params[:id], excludes: excludes)
 
     @accession['accession_date'] = t('accession.accession_date_unknown') if @accession['accession_date'] == "9999-12-31"
 
-    flash[:info] = t("accession._frontend.messages.suppressed_info") # TODO JSONModelI18nWrapper.new(:accession => @accession)) if @accession.suppressed
+    flash[:info] = t("accession._frontend.messages.suppressed_info") if @accession.suppressed
   end
 
   def new
@@ -48,7 +48,7 @@ class AccessionsController < ApplicationController
 
       if acc
         @accession.populate_from_accession(acc)
-        flash.now[:info] = t("accession._frontend.messages.spawned") # TODO JSONModelI18nWrapper.new(:accession => acc))
+        flash.now[:info] = t("accession._frontend.messages.spawned", accession_title: acc.title) 
         flash[:spawned_from_accession] = acc.id
       end
     end
@@ -111,7 +111,7 @@ class AccessionsController < ApplicationController
                 :model => Accession,
                 :on_invalid => ->() { render action: "new" },
                 :on_valid => ->(id) {
-                    flash[:success] = t("accession._frontend.messages.created") # TODO JSONModelI18nWrapper.new(:accession => @accession))
+                    flash[:success] = t("accession._frontend.messages.created", accession_title: @accession.title) 
                     if @accession["is_slug_auto"] == false &&
                        @accession["slug"] == nil &&
                        params["accession"] &&
@@ -132,7 +132,7 @@ class AccessionsController < ApplicationController
                   return render action: "edit"
                 },
                 :on_valid => ->(id) {
-                  flash[:success] = t("accession._frontend.messages.updated") # TODO JSONModelI18nWrapper.new(:accession => @accession))
+                  flash[:success] = t("accession._frontend.messages.updated", accession_title: @accession.title) 
                   if @accession["is_slug_auto"] == false &&
                      @accession["slug"] == nil &&
                      params["accession"] &&
@@ -149,7 +149,7 @@ class AccessionsController < ApplicationController
     accession = Accession.find(params[:id])
     accession.set_suppressed(true)
 
-    flash[:success] = t("accession._frontend.messages.suppressed") # TODO JSONModelI18nWrapper.new(:accession => accession))
+    flash[:success] = t("accession._frontend.messages.suppressed", accession_title: accession.title) 
     redirect_to(:controller => :accessions, :action => :show, :id => params[:id])
   end
 
@@ -158,7 +158,7 @@ class AccessionsController < ApplicationController
     accession = Accession.find(params[:id])
     accession.set_suppressed(false)
 
-    flash[:success] = t("accession._frontend.messages.unsuppressed") # TODO JSONModelI18nWrapper.new(:accession => accession))
+    flash[:success] = t("accession._frontend.messages.unsuppressed", accession_title: accession.title) 
     redirect_to(:controller => :accessions, :action => :show, :id => params[:id])
   end
 
@@ -172,7 +172,7 @@ class AccessionsController < ApplicationController
       return redirect_to(:controller => :accessions, :action => :show, :id => params[:id])
     end
 
-    flash[:success] = t("accession._frontend.messages.deleted") # TODO JSONModelI18nWrapper.new(:accession => accession))
+    flash[:success] = t("accession._frontend.messages.deleted", accession_title: accession.title) 
     redirect_to(:controller => :accessions, :action => :index, :deleted_uri => accession.uri)
   end
 

--- a/frontend/app/controllers/archival_objects_controller.rb
+++ b/frontend/app/controllers/archival_objects_controller.rb
@@ -18,7 +18,7 @@ class ArchivalObjectsController < ApplicationController
     if params[:accession_id]
       acc = Accession.find(params[:accession_id], find_opts)
       @archival_object.populate_from_accession(acc)
-      flash.now[:info] = t("archival_object._frontend.messages.spawned", accession_title: @archival_object.parent) 
+      flash.now[:info] = t("archival_object._frontend.messages.spawned", accession_display_string: @accession.parent) 
       flash[:spawned_from_accession] = acc.id
     end
 
@@ -59,8 +59,8 @@ class ArchivalObjectsController < ApplicationController
                   # TODO JSONModelI18nWrapper.new(:archival_object => @archival_object, :resource => @archival_object['resource']['_resolved'], :parent => @archival_object['parent']['_resolved']).enable_parse_mixed_content!(url_for(:root)))
                   # TODO JSONModelI18nWrapper.new(:archival_object => @archival_object, :resource => @archival_object['resource']['_resolved']).enable_parse_mixed_content!(url_for(:root)))
                   success_message = @archival_object.parent ?
-                                      t("archival_object._frontend.messages.created_with_parent", archival_object_title: @archival_object.title, resource_title: resource['title'], parent_title: parent['title']) :
-                                      t("archival_object._frontend.messages.created", archival_object_title: @archival_object.title, resource_title: resource['title'])
+                                      t("archival_object._frontend.messages.created_with_parent", archival_object_display_string: @archival_object.title, resource_title: resource['title'], parent_display_string: parent['title']) :
+                                      t("archival_object._frontend.messages.created", archival_object_display_string: @archival_object.title, resource_title: resource['title'])
                   if params.has_key?(:plus_one)
                     flash[:success] = success_message
                   else
@@ -101,8 +101,8 @@ class ArchivalObjectsController < ApplicationController
                 :on_valid => ->(id) {
                   
                   flash_success = parent ?
-                    t("archival_object._frontend.messages.updated_with_parent", archival_object_title: @archival_object.title) :
-                    t("archival_object._frontend.messages.updated", archival_object_title: @archival_object.title)
+                    t("archival_object._frontend.messages.updated_with_parent", archival_object_display_string: @archival_object.title) :
+                    t("archival_object._frontend.messages.updated", archival_object_display_string: @archival_object.title)
                   flash.now[:success] = flash_success
                   if @archival_object["is_slug_auto"] == false &&
                      @archival_object["slug"] == nil &&
@@ -184,7 +184,7 @@ class ArchivalObjectsController < ApplicationController
       if response.code == '200'
         @archival_object = JSONModel(:archival_object).find(params[:id], find_opts)
         resource = @archival_object['resource']['_resolved']
-        flash[:success] = t("archival_object._frontend.messages.transfer_success", archival_object_title: @archival_object.title, resource_title: resource['title']) 
+        flash[:success] = t("archival_object._frontend.messages.transfer_success", archival_object_display_string: @archival_object.title, resource_title: resource['title']) 
         redirect_to :controller => :resources, :action => :edit, :id => JSONModel(:resource).id_for(params["transfer"]["ref"]), :anchor => "tree::archival_object_#{params[:id]}"
       else
         raise ASUtils.json_parse(response.body)['error'].to_s
@@ -213,7 +213,7 @@ class ArchivalObjectsController < ApplicationController
       return redirect_to resolver.view_uri
     end
 
-    flash[:success] = t("archival_object._frontend.messages.deleted", archival_object_title: archival_object.title) 
+    flash[:success] = t("archival_object._frontend.messages.deleted", archival_object_display_string: archival_object.title) 
 
     if previous_record
       redirect_to :controller => :resources, :action => :show, :id => JSONModel(:resource).id_for(archival_object['resource']['ref']), :anchor => "tree::archival_object_#{JSONModel(:archival_object).id_for(previous_record['uri'])}"
@@ -288,7 +288,7 @@ class ArchivalObjectsController < ApplicationController
     response = JSONModel::HTTP.post_form("#{@archival_object.uri}/publish")
 
     if response.code == '200'
-      flash[:success] = t("archival_object._frontend.messages.published", archival_object_title: @archival_object.title) 
+      flash[:success] = t("archival_object._frontend.messages.published", archival_object_display_string: @archival_object.title) 
     else
       flash[:error] = ASUtils.json_parse(response.body)['error'].to_s
     end
@@ -303,7 +303,7 @@ class ArchivalObjectsController < ApplicationController
     response = JSONModel::HTTP.post_form("#{@archival_object.uri}/unpublish")
 
     if response.code == '200'
-      flash[:success] = t("archival_object._frontend.messages.unpublished", archival_object_title: @archival_object.title) 
+      flash[:success] = t("archival_object._frontend.messages.unpublished", archival_object_display_string: @archival_object.title) 
     else
       flash[:error] = ASUtils.json_parse(response.body)['error'].to_s
     end
@@ -327,7 +327,7 @@ class ArchivalObjectsController < ApplicationController
     archival_object = JSONModel(:archival_object).find(params[:id])
     archival_object.set_suppressed(true)
 
-    flash[:success] = t("archival_object._frontend.messages.suppressed", archival_object_title: archival_object.title) 
+    flash[:success] = t("archival_object._frontend.messages.suppressed", archival_object_display_string: archival_object.title) 
     redirect_to(:controller => :resources, :action => :show, :id => JSONModel(:resource).id_for(archival_object['resource']['ref']), :anchor => "tree::archival_object_#{params[:id]}")
   end
 
@@ -336,7 +336,7 @@ class ArchivalObjectsController < ApplicationController
     archival_object = JSONModel(:archival_object).find(params[:id])
     archival_object.set_suppressed(false)
 
-    flash[:success] = t("archival_object._frontend.messages.unsuppressed", archival_object_title: archival_object.title) 
+    flash[:success] = t("archival_object._frontend.messages.unsuppressed", archival_object_display_string: archival_object.title) 
     redirect_to(:controller => :resources, :action => :show, :id => JSONModel(:resource).id_for(archival_object['resource']['ref']), :anchor => "tree::archival_object_#{params[:id]}")
   end
 

--- a/frontend/app/controllers/archival_objects_controller.rb
+++ b/frontend/app/controllers/archival_objects_controller.rb
@@ -288,7 +288,7 @@ class ArchivalObjectsController < ApplicationController
     response = JSONModel::HTTP.post_form("#{@archival_object.uri}/publish")
 
     if response.code == '200'
-      flash[:success] = t("archival_object._frontend.messages.published", archival_object_display_string: @archival_object.title) 
+      flash[:success] = t("archival_object._frontend.messages.published", archival_object_title: @archival_object.title) 
     else
       flash[:error] = ASUtils.json_parse(response.body)['error'].to_s
     end
@@ -303,7 +303,7 @@ class ArchivalObjectsController < ApplicationController
     response = JSONModel::HTTP.post_form("#{@archival_object.uri}/unpublish")
 
     if response.code == '200'
-      flash[:success] = t("archival_object._frontend.messages.unpublished", archival_object_display_string: @archival_object.title) 
+      flash[:success] = t("archival_object._frontend.messages.unpublished", archival_object_title: @archival_object.title) 
     else
       flash[:error] = ASUtils.json_parse(response.body)['error'].to_s
     end
@@ -327,7 +327,7 @@ class ArchivalObjectsController < ApplicationController
     archival_object = JSONModel(:archival_object).find(params[:id])
     archival_object.set_suppressed(true)
 
-    flash[:success] = t("archival_object._frontend.messages.suppressed", archival_object_display_string: archival_object.title) 
+    flash[:success] = t("archival_object._frontend.messages.suppressed", archival_object_title: archival_object.title) 
     redirect_to(:controller => :resources, :action => :show, :id => JSONModel(:resource).id_for(archival_object['resource']['ref']), :anchor => "tree::archival_object_#{params[:id]}")
   end
 
@@ -336,7 +336,7 @@ class ArchivalObjectsController < ApplicationController
     archival_object = JSONModel(:archival_object).find(params[:id])
     archival_object.set_suppressed(false)
 
-    flash[:success] = t("archival_object._frontend.messages.unsuppressed", archival_object_display_string: archival_object.title) 
+    flash[:success] = t("archival_object._frontend.messages.unsuppressed", archival_object_title: archival_object.title) 
     redirect_to(:controller => :resources, :action => :show, :id => JSONModel(:resource).id_for(archival_object['resource']['ref']), :anchor => "tree::archival_object_#{params[:id]}")
   end
 

--- a/frontend/app/controllers/assessments_controller.rb
+++ b/frontend/app/controllers/assessments_controller.rb
@@ -65,7 +65,7 @@ class AssessmentsController < ApplicationController
                   render action: "new"
                 },
                 :on_valid => ->(id) {
-                    flash[:success] = t("assessment._frontend.messages.created") # TODO JSONModelI18nWrapper.new(:assessment => @assessment))
+                    flash[:success] = t("assessment._frontend.messages.created")
                     redirect_to(:controller => :assessments,
                                 :action => :edit,
                                 :id => id) })
@@ -82,7 +82,7 @@ class AssessmentsController < ApplicationController
                   return render action: "edit"
                 },
                 :on_valid => ->(id) {
-                  flash[:success] = t("assessment._frontend.messages.updated") # TODO JSONModelI18nWrapper.new(:assessment => @assessment))
+                  flash[:success] = t("assessment._frontend.messages.updated") 
                   redirect_to :controller => :assessments, :action => :edit, :id => id
                 })
   end
@@ -92,7 +92,7 @@ class AssessmentsController < ApplicationController
     assessment = JSONModel(:assessment).find(params[:id])
     assessment.delete
 
-    flash[:success] = t("assessment._frontend.messages.deleted") # TODO JSONModelI18nWrapper.new(:assessment => assessment))
+    flash[:success] = t("assessment._frontend.messages.deleted") 
     redirect_to(:controller => :assessments, :action => :index, :deleted_uri => assessment.uri)
   end
 

--- a/frontend/app/controllers/classification_terms_controller.rb
+++ b/frontend/app/controllers/classification_terms_controller.rb
@@ -33,8 +33,7 @@ class ClassificationTermsController < ApplicationController
                 :find_opts => find_opts,
                 :on_invalid => ->() { render_aspace_partial :partial => "new_inline" },
                 :on_valid => ->(id) {
-                  # TODO JSONModelI18nWrapper.new(:classification_term => @classification_term, :classification => @classification_term['classification']['_resolved'], :parent => @classification_term['parent']['_resolved']))
-                  # TODO JSONModelI18nWrapper.new(:classification_term => @classification_term, :classification => @classification_term['classification']['_resolved']))
+                 
                   success_message = @classification_term.parent ?
                                       t("classification_term._frontend.messages.created_with_parent", classification_term_title: @classification_term.title) :
                                       t("classification_term._frontend.messages.created", classification_term_title: @classification_term.title)
@@ -72,11 +71,10 @@ class ClassificationTermsController < ApplicationController
                 :obj => @classification_term,
                 :on_invalid => ->() { return render_aspace_partial :partial => "edit_inline" },
                 :on_valid => ->(id) {
-                  # TODO JSONModelI18nWrapper.new(:classification_term => @classification_term, :classification => @classification_term['classification']['_resolved'], :parent => parent))
-                  # TODO JSONModelI18nWrapper.new(:classification_term => @classification_term, :classification => @classification_term['classification']['_resolved']))
+
                   success_message = parent ?
-                    t("classification_term._frontend.messages.updated_with_parent") :
-                    t("classification_term._frontend.messages.updated")
+                    t("classification_term._frontend.messages.updated_with_parent", classification_term_title: @classification_term.title) :
+                    t("classification_term._frontend.messages.updated", classification_term_title: @classification_term.title)
                   flash.now[:success] = success_message
 
                   if @classification_term["is_slug_auto"] == false &&
@@ -115,7 +113,7 @@ class ClassificationTermsController < ApplicationController
     classification_term = JSONModel(:classification_term).find(params[:id])
     classification_term.delete
 
-    flash[:success] = t("classification_term._frontend.messages.deleted") # TODO JSONModelI18nWrapper.new(:classification_term => classification_term))
+    flash[:success] = t("classification_term._frontend.messages.deleted", classification_term_title: classification_term.title) 
 
     resolver = Resolver.new(classification_term['classification']['ref'])
     redirect_to resolver.view_uri

--- a/frontend/app/controllers/classifications_controller.rb
+++ b/frontend/app/controllers/classifications_controller.rb
@@ -70,7 +70,7 @@ class ClassificationsController < ApplicationController
     },
       :on_valid => ->(id) {
 
-      flash[:success] = t("classification._frontend.messages.created") # TODO JSONModelI18nWrapper.new(:classification => @classification))
+      flash[:success] = t("classification._frontend.messages.created", classification_title: @classification.title) 
 
       if @classification["is_slug_auto"] == false &&
           @classification["slug"] == nil &&
@@ -96,7 +96,7 @@ class ClassificationsController < ApplicationController
       render_aspace_partial :partial => "edit_inline"
     },
       :on_valid => ->(id) {
-      flash.now[:success] = t("classification._frontend.messages.updated") # TODO JSONModelI18nWrapper.new(:classification => @classification))
+      flash.now[:success] = t("classification._frontend.messages.updated", classification_title: @classification.title) 
 
       if @classification["is_slug_auto"] == false &&
           @classification["slug"] == nil &&
@@ -115,7 +115,7 @@ class ClassificationsController < ApplicationController
     classification = JSONModel(:classification).find(params[:id])
     classification.delete
 
-    flash[:success] = t("classification._frontend.messages.deleted") # TODO JSONModelI18nWrapper.new(:classification => classification))
+    flash[:success] = t("classification._frontend.messages.deleted", classification_title: classification.title) 
     redirect_to(:controller => :classifications, :action => :index, :deleted_uri => classification.uri)
   end
 

--- a/frontend/app/controllers/digital_object_components_controller.rb
+++ b/frontend/app/controllers/digital_object_components_controller.rb
@@ -41,19 +41,19 @@ class DigitalObjectComponentsController < ApplicationController
   def create
     handle_crud(:instance => :digital_object_component,
                 :find_opts => find_opts,
-                :on_invalid => ->() { render_aspace_partial :partial => "new_inline" },
+                :on_invalid => ->() { return render_aspace_partial :partial => "new_inline" },
                 :on_valid => ->(id) {
                   # Refetch the record to ensure all sub records are resolved
                   # (this object isn't marked as stale upon create like Archival Objects,
                   # so need to do it manually)
                   @digital_object_component = JSONModel(:digital_object_component).find(id, find_opts)
-
-                  # TODO JSONModelI18nWrapper.new(:digital_object_component => @digital_object_component, :digital_object => @digital_object_component['digital_object']['_resolved'], :parent => @digital_object_component['parent']['_resolved']).enable_parse_mixed_content!(url_for(:root)))
-                  # TODO JSONModelI18nWrapper.new(:digital_object_component => @digital_object_component, :digital_object => @digital_object_component['digital_object']['_resolved']).enable_parse_mixed_content!(url_for(:root)))
+                  digital_object = @digital_object_component['digital_object']['_resolved']
+                  parent = @digital_object_component['parent']? @digital_object_component['parent']['_resolved'] : false
+                  
                   flash[:success] = @digital_object_component.parent ?
-                    t("digital_object_component._frontend.messages.created_with_parent") :
-                    t("digital_object_component._frontend.messages.created")
-
+                    t("digital_object_component._frontend.messages.created_with_parent", digital_object_component_title: @digital_object_component.title, digital_object_title: digital_object['title'], parent_title: parent['title']) :
+                    t("digital_object_component._frontend.messages.created", digital_object_component_title: @digital_object_component.title, digital_object_title: digital_object['title'])
+                    
                   if @digital_object_component["is_slug_auto"] == false &&
                      @digital_object_component["slug"] == nil &&
                      params["digital_object_component"] &&
@@ -64,7 +64,7 @@ class DigitalObjectComponentsController < ApplicationController
 
                   render_aspace_partial :partial => "digital_object_components/edit_inline"
                 })
-  end
+              end
 
 
   def update
@@ -78,11 +78,10 @@ class DigitalObjectComponentsController < ApplicationController
                 :obj => @digital_object_component,
                 :on_invalid => ->() { return render_aspace_partial :partial => "edit_inline" },
                 :on_valid => ->(id) {
-                  # TODO JSONModelI18nWrapper.new(:digital_object_component => @digital_object_component, :digital_object => digital_object, :parent => parent).enable_parse_mixed_content!(url_for(:root))) :
-                  # TODO JSONModelI18nWrapper.new(:digital_object_component => @digital_object_component, :digital_object => digital_object).enable_parse_mixed_content!(url_for(:root)))
+                 
                   flash.now[:success] = parent ?
-                    t("digital_object_component._frontend.messages.updated_with_parent") :
-                    t("digital_object_component._frontend.messages.updated")
+                    t("digital_object_component._frontend.messages.updated_with_parent", digital_object_component_title: @digital_object_component.title) :
+                    t("digital_object_component._frontend.messages.updated", digital_object_component_title: @digital_object_component.title)
                   if @digital_object_component["is_slug_auto"] == false &&
                      @digital_object_component["slug"] == nil &&
                      params["digital_object_component"] &&
@@ -105,7 +104,7 @@ class DigitalObjectComponentsController < ApplicationController
     @digital_object_id = params['digital_object_id']
     @digital_object_component = JSONModel(:digital_object_component).find(params[:id], find_opts)
 
-    flash.now[:info] = t("digital_object_component._frontend.messages.suppressed_info") # TODO JSONModelI18nWrapper.new(:digital_object_component => @digital_object_component).enable_parse_mixed_content!(url_for(:root))) if @digital_object_component.suppressed
+    flash.now[:info] = t("digital_object_component._frontend.messages.suppressed_info") if @digital_object_component.suppressed
 
     render_aspace_partial :partial => "digital_object_components/show_inline" if inline?
   end
@@ -115,7 +114,7 @@ class DigitalObjectComponentsController < ApplicationController
     digital_object_component = JSONModel(:digital_object_component).find(params[:id])
     digital_object_component.delete
 
-    flash[:success] = t("digital_object_component._frontend.messages.deleted") # TODO JSONModelI18nWrapper.new(:digital_object_component => digital_object_component).enable_parse_mixed_content!(url_for(:root)))
+    flash[:success] = t("digital_object_component._frontend.messages.deleted", digital_object_component_title: digital_object_component.title) 
 
     resolver = Resolver.new(digital_object_component['digital_object']['ref'])
     redirect_to resolver.view_uri
@@ -233,7 +232,7 @@ class DigitalObjectComponentsController < ApplicationController
     digital_object_component = JSONModel(:digital_object_component).find(params[:id])
     digital_object_component.set_suppressed(true)
 
-    flash[:success] = t("digital_object_component._frontend.messages.suppressed") # TODO JSONModelI18nWrapper.new(:digital_object_component => digital_object_component).enable_parse_mixed_content!(url_for(:root)))
+    flash[:success] = t("digital_object_component._frontend.messages.suppressed", digital_object_component_title: digital_object_component.title) 
     redirect_to(:controller => :digital_objects, :action => :show, :id => JSONModel(:digital_object).id_for(digital_object_component['digital_object']['ref']), :anchor => "tree::digital_object_component_#{params[:id]}")
   end
 
@@ -242,7 +241,7 @@ class DigitalObjectComponentsController < ApplicationController
     digital_object_component = JSONModel(:digital_object_component).find(params[:id])
     digital_object_component.set_suppressed(false)
 
-    flash[:success] = t("digital_object_component._frontend.messages.unsuppressed") # TODO JSONModelI18nWrapper.new(:digital_object_component => digital_object_component).enable_parse_mixed_content!(url_for(:root)))
+    flash[:success] = t("digital_object_component._frontend.messages.unsuppressed", digital_object_component_title: digital_object_component.title) 
     redirect_to(:controller => :digital_objects, :action => :show, :id => JSONModel(:digital_object).id_for(digital_object_component['digital_object']['ref']), :anchor => "tree::digital_object_component_#{params[:id]}")
   end
 

--- a/frontend/app/controllers/digital_object_components_controller.rb
+++ b/frontend/app/controllers/digital_object_components_controller.rb
@@ -51,8 +51,8 @@ class DigitalObjectComponentsController < ApplicationController
                   parent = @digital_object_component['parent']? @digital_object_component['parent']['_resolved'] : false
                   
                   flash[:success] = @digital_object_component.parent ?
-                    t("digital_object_component._frontend.messages.created_with_parent", digital_object_component_title: @digital_object_component.title, digital_object_title: digital_object['title'], parent_title: parent['title']) :
-                    t("digital_object_component._frontend.messages.created", digital_object_component_title: @digital_object_component.title, digital_object_title: digital_object['title'])
+                    t("digital_object_component._frontend.messages.created_with_parent", digital_object_component_display_string: @digital_object_component.title, digital_object_title: digital_object['title'], parent_display_string: parent['title']) :
+                    t("digital_object_component._frontend.messages.created", digital_object_component_display_string: @digital_object_component.title, digital_object_title: digital_object['title'])
                     
                   if @digital_object_component["is_slug_auto"] == false &&
                      @digital_object_component["slug"] == nil &&
@@ -80,8 +80,8 @@ class DigitalObjectComponentsController < ApplicationController
                 :on_valid => ->(id) {
                  
                   flash.now[:success] = parent ?
-                    t("digital_object_component._frontend.messages.updated_with_parent", digital_object_component_title: @digital_object_component.title) :
-                    t("digital_object_component._frontend.messages.updated", digital_object_component_title: @digital_object_component.title)
+                    t("digital_object_component._frontend.messages.updated_with_parent", digital_object_component_display_string: @digital_object_component.title) :
+                    t("digital_object_component._frontend.messages.updated", digital_object_component_display_string: @digital_object_component.title)
                   if @digital_object_component["is_slug_auto"] == false &&
                      @digital_object_component["slug"] == nil &&
                      params["digital_object_component"] &&
@@ -114,7 +114,7 @@ class DigitalObjectComponentsController < ApplicationController
     digital_object_component = JSONModel(:digital_object_component).find(params[:id])
     digital_object_component.delete
 
-    flash[:success] = t("digital_object_component._frontend.messages.deleted", digital_object_component_title: digital_object_component.title) 
+    flash[:success] = t("digital_object_component._frontend.messages.deleted", digital_object_component_display_string: digital_object_component.title) 
 
     resolver = Resolver.new(digital_object_component['digital_object']['ref'])
     redirect_to resolver.view_uri
@@ -232,7 +232,7 @@ class DigitalObjectComponentsController < ApplicationController
     digital_object_component = JSONModel(:digital_object_component).find(params[:id])
     digital_object_component.set_suppressed(true)
 
-    flash[:success] = t("digital_object_component._frontend.messages.suppressed", digital_object_component_title: digital_object_component.title) 
+    flash[:success] = t("digital_object_component._frontend.messages.suppressed", digital_object_component_display_string: digital_object_component.title) 
     redirect_to(:controller => :digital_objects, :action => :show, :id => JSONModel(:digital_object).id_for(digital_object_component['digital_object']['ref']), :anchor => "tree::digital_object_component_#{params[:id]}")
   end
 
@@ -241,7 +241,7 @@ class DigitalObjectComponentsController < ApplicationController
     digital_object_component = JSONModel(:digital_object_component).find(params[:id])
     digital_object_component.set_suppressed(false)
 
-    flash[:success] = t("digital_object_component._frontend.messages.unsuppressed", digital_object_component_title: digital_object_component.title) 
+    flash[:success] = t("digital_object_component._frontend.messages.unsuppressed", digital_object_component_display_string: digital_object_component.title) 
     redirect_to(:controller => :digital_objects, :action => :show, :id => JSONModel(:digital_object).id_for(digital_object_component['digital_object']['ref']), :anchor => "tree::digital_object_component_#{params[:id]}")
   end
 

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -729,12 +729,12 @@ en:
     component_links: Linked Components
     _frontend:
       messages:
-        created: Accession <strong>%{accession_display_string}</strong> created
-        unsuppressed: Accession <strong>%{accession_display_string}</strong> unsuppressed
-        updated: Accession <strong>%{accession_display_string}</strong> updated
-        suppressed: Accession <strong>%{accession_display_string}</strong> suppressed
+        created: Accession <strong>%{accession_title}</strong> created
+        unsuppressed: Accession <strong>%{accession_title}</strong> unsuppressed
+        updated: Accession <strong>%{accession_title}</strong> updated
+        suppressed: Accession <strong>%{accession_title}</strong> suppressed
         suppressed_info: Accession is suppressed and cannot be edited
-        deleted: Accession <strong>%{accession_display_string}</strong> deleted
+        deleted: Accession <strong>%{accession_title}</strong> deleted
         transfer_description: Transfer this accession to...
         transfer_target: Select a repository to transfer into
         spawned: "This Accession has been spawned from Accession <strong>%{accession_display_string}</strong>. This record is unsaved. You must click Save for the record to be created in the system."
@@ -827,21 +827,21 @@ en:
     new_title: New Archival Object
     _frontend:
       messages:
-        created: Archival Object <strong>%{archival_object_display_string}</strong> on Resource <strong>%{resource_title}</strong> created
-        created_with_parent: Archival Object <strong>%{archival_object_display_string}</strong> created as child of <strong>%{parent_display_string}</strong> on Resource <strong>%{resource_title}</strong>
-        updated: Archival Object <strong>%{archival_object_display_string}</strong> updated
-        updated_with_parent: Archival Object <strong>%{archival_object_display_string}</strong> updated
+        created: Archival Object <strong>%{archival_object_title}</strong> on Resource <strong>%{resource_title}</strong> created
+        created_with_parent: Archival Object <strong>%{archival_object_title}</strong> created as child of <strong>%{parent_title}</strong> on Resource <strong>%{resource_title}</strong>
+        updated: Archival Object <strong>%{archival_object_title}</strong> updated
+        updated_with_parent: Archival Object <strong>%{archival_object_title}</strong> updated
         please_select_a_resource_for_transfer: Please choose a Resource
-        transfer_success: Successfully transferred Archival Object <strong>%{archival_object_display_string}</strong> to Resource <strong>%{resource_title}</strong>
+        transfer_success: Successfully transferred Archival Object <strong>%{archival_object_title}</strong> to Resource <strong>%{resource_title}</strong>
         transfer_error: "Unable to transfer Archival Object due to an error or conflict: <pre>%{exception}</pre>"
-        deleted: "Archival Object <strong>%{archival_object_display_string}</strong> deleted"
+        deleted: "Archival Object <strong>%{archival_object_title}</strong> deleted"
         published: "The Archival Object <strong>%{archival_object_title}</strong>, its children, subrecords and components have been published"
         unpublished: "The Archival Object <strong>%{archival_object_title}</strong>, its children, subrecords and components have been unpublished"
         unsuppressed: Archival Object <strong>%{archival_object_title}</strong> unsuppressed
         suppressed: Archival Object <strong>%{archival_object_title}</strong> suppressed
         suppressed_info: Archival Object is suppressed and cannot be edited
         has_unpublished_ancestor: Please be aware this record has an ancestor that is unpublished.
-        spawned: "This Archival Object has been spawned from Accession <strong>%{accession_display_string}</strong>. This record is unsaved. You must click Save for the record to be created in the system."
+        spawned: "This Archival Object has been spawned from Accession <strong>%{accession_title}</strong>. This record is unsaved. You must click Save for the record to be created in the system."
         delete_conflict: "Archival Object could not be deleted: <pre>%{error}</pre>"
         spawn_placeholder: "<em>Spawned component will be inserted here</em>"
         spawn_menu_before: Insert spawned component before
@@ -985,13 +985,13 @@ en:
   digital_object_component:
     _frontend:
       messages:
-        created_with_parent: Digital Object Component <strong>%{digital_object_component_display_string}</strong> created as child of <strong>%{parent_display_string}</strong> on Digital Object <strong>%{digital_object_title}</strong>
-        created: Digital Object Component <strong>%{digital_object_component_display_string}</strong> created on Digital Object <strong>%{digital_object_title}</strong>
-        updated_with_parent: Digital Object Component <strong>%{digital_object_component_display_string}</strong> updated
-        updated: Digital Object Component <strong>%{digital_object_component_display_string}</strong> updated
-        deleted: Digital Object Component <strong>%{digital_object_component_display_string}</strong> deleted
-        unsuppressed: Digital Object Component <strong>%{digital_object_component_display_string}</strong> unsuppressed
-        suppressed: Digital Object Component <strong>%{digital_object_component_display_string}</strong> suppressed
+        created_with_parent: Digital Object Component <strong>%{digital_object_component_title}</strong> created as child of <strong>%{parent_title}</strong> on Digital Object <strong>%{digital_object_title}</strong>
+        created: Digital Object Component <strong>%{digital_object_component_title}</strong> created on Digital Object <strong>%{digital_object_title}</strong>
+        updated_with_parent: Digital Object Component <strong>%{digital_object_component_title}</strong> updated
+        updated: Digital Object Component <strong>%{digital_object_component_title}</strong> updated
+        deleted: Digital Object Component <strong>%{digital_object_component_title}</strong> deleted
+        unsuppressed: Digital Object Component <strong>%{digital_object_component_title}</strong> unsuppressed
+        suppressed: Digital Object Component <strong>%{digital_object_component_title}</strong> suppressed
         suppressed_info: Digital Object Component is suppressed and cannot be edited
         has_unpublished_ancestor: Please be aware this record has an ancestor that is unpublished.
       section:

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -835,10 +835,10 @@ en:
         transfer_success: Successfully transferred Archival Object <strong>%{archival_object_display_string}</strong> to Resource <strong>%{resource_title}</strong>
         transfer_error: "Unable to transfer Archival Object due to an error or conflict: <pre>%{exception}</pre>"
         deleted: "Archival Object <strong>%{archival_object_display_string}</strong> deleted"
-        published: "The Archival Object <strong>%{archival_object_display_string}</strong>, its children, subrecords and components have been published"
-        unpublished: "The Archival Object <strong>%{archival_object_display_string}</strong>, its children, subrecords and components have been unpublished"
-        unsuppressed: Archival Object <strong>%{archival_object_display_string}</strong> unsuppressed
-        suppressed: Archival Object <strong>%{archival_object_display_string}</strong> suppressed
+        published: "The Archival Object <strong>%{archival_object_title}</strong>, its children, subrecords and components have been published"
+        unpublished: "The Archival Object <strong>%{archival_object_title}</strong>, its children, subrecords and components have been unpublished"
+        unsuppressed: Archival Object <strong>%{archival_object_title}</strong> unsuppressed
+        suppressed: Archival Object <strong>%{archival_object_title}</strong> suppressed
         suppressed_info: Archival Object is suppressed and cannot be edited
         has_unpublished_ancestor: Please be aware this record has an ancestor that is unpublished.
         spawned: "This Archival Object has been spawned from Accession <strong>%{accession_display_string}</strong>. This record is unsaved. You must click Save for the record to be created in the system."

--- a/frontend/config/locales/en.yml
+++ b/frontend/config/locales/en.yml
@@ -729,12 +729,12 @@ en:
     component_links: Linked Components
     _frontend:
       messages:
-        created: Accession <strong>%{accession_title}</strong> created
-        unsuppressed: Accession <strong>%{accession_title}</strong> unsuppressed
-        updated: Accession <strong>%{accession_title}</strong> updated
-        suppressed: Accession <strong>%{accession_title}</strong> suppressed
+        created: Accession <strong>%{accession_display_string}</strong> created
+        unsuppressed: Accession <strong>%{accession_display_string}</strong> unsuppressed
+        updated: Accession <strong>%{accession_display_string}</strong> updated
+        suppressed: Accession <strong>%{accession_display_string}</strong> suppressed
         suppressed_info: Accession is suppressed and cannot be edited
-        deleted: Accession <strong>%{accession_title}</strong> deleted
+        deleted: Accession <strong>%{accession_display_string}</strong> deleted
         transfer_description: Transfer this accession to...
         transfer_target: Select a repository to transfer into
         spawned: "This Accession has been spawned from Accession <strong>%{accession_display_string}</strong>. This record is unsaved. You must click Save for the record to be created in the system."
@@ -827,21 +827,21 @@ en:
     new_title: New Archival Object
     _frontend:
       messages:
-        created: Archival Object <strong>%{archival_object_title}</strong> on Resource <strong>%{resource_title}</strong> created
-        created_with_parent: Archival Object <strong>%{archival_object_title}</strong> created as child of <strong>%{parent_title}</strong> on Resource <strong>%{resource_title}</strong>
-        updated: Archival Object <strong>%{archival_object_title}</strong> updated
-        updated_with_parent: Archival Object <strong>%{archival_object_title}</strong> updated
+        created: Archival Object <strong>%{archival_object_display_string}</strong> on Resource <strong>%{resource_title}</strong> created
+        created_with_parent: Archival Object <strong>%{archival_object_display_string}</strong> created as child of <strong>%{parent_display_string}</strong> on Resource <strong>%{resource_title}</strong>
+        updated: Archival Object <strong>%{archival_object_display_string}</strong> updated
+        updated_with_parent: Archival Object <strong>%{archival_object_display_string}</strong> updated
         please_select_a_resource_for_transfer: Please choose a Resource
-        transfer_success: Successfully transferred Archival Object <strong>%{archival_object_title}</strong> to Resource <strong>%{resource_title}</strong>
+        transfer_success: Successfully transferred Archival Object <strong>%{archival_object_display_string}</strong> to Resource <strong>%{resource_title}</strong>
         transfer_error: "Unable to transfer Archival Object due to an error or conflict: <pre>%{exception}</pre>"
-        deleted: "Archival Object <strong>%{archival_object_title}</strong> deleted"
-        published: "The Archival Object <strong>%{archival_object_title}</strong>, its children, subrecords and components have been published"
-        unpublished: "The Archival Object <strong>%{archival_object_title}</strong>, its children, subrecords and components have been unpublished"
-        unsuppressed: Archival Object <strong>%{archival_object_title}</strong> unsuppressed
-        suppressed: Archival Object <strong>%{archival_object_title}</strong> suppressed
+        deleted: "Archival Object <strong>%{archival_object_display_string}</strong> deleted"
+        published: "The Archival Object <strong>%{archival_object_display_string}</strong>, its children, subrecords and components have been published"
+        unpublished: "The Archival Object <strong>%{archival_object_display_string}</strong>, its children, subrecords and components have been unpublished"
+        unsuppressed: Archival Object <strong>%{archival_object_display_string}</strong> unsuppressed
+        suppressed: Archival Object <strong>%{archival_object_display_string}</strong> suppressed
         suppressed_info: Archival Object is suppressed and cannot be edited
         has_unpublished_ancestor: Please be aware this record has an ancestor that is unpublished.
-        spawned: "This Archival Object has been spawned from Accession <strong>%{accession_title}</strong>. This record is unsaved. You must click Save for the record to be created in the system."
+        spawned: "This Archival Object has been spawned from Accession <strong>%{accession_display_string}</strong>. This record is unsaved. You must click Save for the record to be created in the system."
         delete_conflict: "Archival Object could not be deleted: <pre>%{error}</pre>"
         spawn_placeholder: "<em>Spawned component will be inserted here</em>"
         spawn_menu_before: Insert spawned component before
@@ -985,13 +985,13 @@ en:
   digital_object_component:
     _frontend:
       messages:
-        created_with_parent: Digital Object Component <strong>%{digital_object_component_title}</strong> created as child of <strong>%{parent_title}</strong> on Digital Object <strong>%{digital_object_title}</strong>
-        created: Digital Object Component <strong>%{digital_object_component_title}</strong> created on Digital Object <strong>%{digital_object_title}</strong>
-        updated_with_parent: Digital Object Component <strong>%{digital_object_component_title}</strong> updated
-        updated: Digital Object Component <strong>%{digital_object_component_title}</strong> updated
-        deleted: Digital Object Component <strong>%{digital_object_component_title}</strong> deleted
-        unsuppressed: Digital Object Component <strong>%{digital_object_component_title}</strong> unsuppressed
-        suppressed: Digital Object Component <strong>%{digital_object_component_title}</strong> suppressed
+        created_with_parent: Digital Object Component <strong>%{digital_object_component_display_string}</strong> created as child of <strong>%{parent_display_string}</strong> on Digital Object <strong>%{digital_object_title}</strong>
+        created: Digital Object Component <strong>%{digital_object_component_display_string}</strong> created on Digital Object <strong>%{digital_object_title}</strong>
+        updated_with_parent: Digital Object Component <strong>%{digital_object_component_display_string}</strong> updated
+        updated: Digital Object Component <strong>%{digital_object_component_display_string}</strong> updated
+        deleted: Digital Object Component <strong>%{digital_object_component_display_string}</strong> deleted
+        unsuppressed: Digital Object Component <strong>%{digital_object_component_display_string}</strong> unsuppressed
+        suppressed: Digital Object Component <strong>%{digital_object_component_display_string}</strong> suppressed
         suppressed_info: Digital Object Component is suppressed and cannot be edited
         has_unpublished_ancestor: Please be aware this record has an ancestor that is unpublished.
       section:


### PR DESCRIPTION
# Summary
![image](https://user-images.githubusercontent.com/84541944/189431274-0082732c-0a2c-4bd6-b219-30b6f532e326.png)
![image](https://user-images.githubusercontent.com/84541944/189431330-2c340e01-6736-476d-bbdd-f6566ab5aa2a.png)


# Screenshots
Assessments
<details>
<img width="922" alt="Screen Shot 2022-09-08 at 7 29 27 PM" src="https://user-images.githubusercontent.com/84541944/189430420-0826f59a-f301-4487-9206-2fcfd85d770d.png">
<img width="894" alt="Screen Shot 2022-09-08 at 7 30 23 PM" src="https://user-images.githubusercontent.com/84541944/189430431-36fe6492-6fe2-4eae-acb8-4ea28f259fc4.png">
<img width="880" alt="Screen Shot 2022-09-08 at 7 31 41 PM" src="https://user-images.githubusercontent.com/84541944/189430436-1f89928b-0ebc-494c-ac1d-9c7d0ec7714e.png">
ssments </details>

Classifications
<details>
<img width="882" alt="Screen Shot 2022-09-09 at 6 33 42 AM" src="https://user-images.githubusercontent.com/84541944/189430767-6fa83694-016b-4360-9d90-c61e7e57d3e6.png">
<img width="865" alt="Screen Shot 2022-09-09 at 6 34 37 AM" src="https://user-images.githubusercontent.com/84541944/189430768-b922076c-5d68-4d07-b48a-9019b4e1eaff.png">
<img width="882" alt="Screen Shot 2022-09-09 at 6 34 49 AM" src="https://user-images.githubusercontent.com/84541944/189430770-4495fd86-0c90-4092-a546-603137da0965.png">
</details>

Classification_term 
<details>
<img width="858" alt="Screen Shot 2022-09-09 at 6 40 35 AM" src="https://user-images.githubusercontent.com/84541944/189430826-2a0d6cfb-5197-4e5a-9c62-c0defb54f1bf.png">
<img width="872" alt="Screen Shot 2022-09-09 at 6 41 39 AM" src="https://user-images.githubusercontent.com/84541944/189430828-afb2366a-e0b5-4a73-aa53-ac9a73435662.png">
<img width="869" alt="Screen Shot 2022-09-09 at 6 42 05 AM" src="https://user-images.githubusercontent.com/84541944/189430830-51da4ff0-4d3a-4f25-b097-b84b234fa0ee.png">
</details>

Digital_object_component
<details>
<img width="1155" alt="Screen Shot 2022-09-08 at 8 00 04 PM" src="https://user-images.githubusercontent.com/84541944/189430885-4c239457-8e9a-4772-849d-47f02384c62a.png">
<img width="1155" alt="Screen Shot 2022-09-08 at 8 00 26 PM" src="https://user-images.githubusercontent.com/84541944/189430887-28c782d4-2c6f-40be-8bd1-dfae97e19ee0.png">
<img width="1170" alt="Screen Shot 2022-09-08 at 8 08 22 PM" src="https://user-images.githubusercontent.com/84541944/189430889-79f3949a-eeaa-4bdf-901d-3a1cb03cd064.png">
<img width="1158" alt="Screen Shot 2022-09-08 at 8 11 12 PM" src="https://user-images.githubusercontent.com/84541944/189430890-e8cb0a81-8387-44aa-876c-99f6fa6c9abd.png">
<img width="1152" alt="Screen Shot 2022-09-08 at 8 12 53 PM" src="https://user-images.githubusercontent.com/84541944/189430891-1ce89191-650c-460a-aae3-f1b6dd2bcb2c.png">
<img width="797" alt="Screen Shot 2022-09-09 at 9 06 27 AM" src="https://user-images.githubusercontent.com/84541944/189430892-40433c54-5ab9-442a-a9a0-ae0379bac6d9.png">
<img width="806" alt="Screen Shot 2022-09-09 at 9 13 13 AM" src="https://user-images.githubusercontent.com/84541944/189430893-51833c6d-b71d-4740-9d95-ee9f34308dd8.png">
</details>

Accession
<details><img width="1187" alt="Screen Shot 2022-09-09 at 6 21 04 AM" src="https://user-images.githubusercontent.com/84541944/189430945-d780a11e-d839-4ca8-951a-144e4ac99fe5.png">
<img width="906" alt="Screen Shot 2022-09-09 at 6 27 42 AM" src="https://user-images.githubusercontent.com/84541944/189430948-9bf58f23-5a26-4f58-9485-43b34d618509.png">
<img width="883" alt="Screen Shot 2022-09-09 at 6 28 02 AM" src="https://user-images.githubusercontent.com/84541944/189430950-38764540-2641-4236-aac1-dec7cb6da097.png">
<img width="882" alt="Screen Shot 2022-09-09 at 6 28 16 AM" src="https://user-images.githubusercontent.com/84541944/189430952-220e9430-3121-428d-82a9-410db0c89f26.png">
<img width="877" alt="Screen Shot 2022-09-09 at 6 28 29 AM" src="https://user-images.githubusercontent.com/84541944/189430953-c5125aea-97e4-4eed-8334-2bf10cd985fd.png">
<img width="850" alt="Screen Shot 2022-09-09 at 6 30 32 AM" src="https://user-images.githubusercontent.com/84541944/189430956-97ecb614-d111-4e4e-8077-504b298ef05c.png">

</details>

archival_objects: Could not navigate to this element code. I implemented the fix for the bug in the code. There are no screenshots that can be provided.


# Related Tickets
Ticket 90 - https://gitlab.com/notch8/archivesspace/-/issues/90

# Acceptance Criteria
I can visit the following pages without hitting a rails error/ Success message displays properly


- [ ] Create assessments
- [ ] Update assessments
- [ ] Delete assessments

- [ ] Create classifications
- [ ] Update classifications
- [ ] Delete classifications

- [ ] Create classification_term
- [ ] Update classification_term
- [ ] Delete classification_term

- [ ] Create digital_object_component
- [ ] Update digital_object_component
- [ ] Delete digital_object_component
- [ ] Suppress digital_object_component
- [ ] Unsuppress digital_object_component

- [ ] Show accession
- [ ] Create accession
- [ ] Update accession
- [ ] Delete accession
- [ ] Suppress accession
- [ ] Unsuppress accession

- [ ] Show archival_object
- [ ] Create archival_object
- [ ] Update archival_object
- [ ] Delete archival_object
- [ ] Suppress archival_object
- [ ] Unsuppress archival_object
- [ ] Unpublish archival_object
- [ ] Publish archival_object
- [ ] Transfer archival_object






